### PR TITLE
docs: codify dependency-exception lifecycle and release closure gates

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -53,6 +53,7 @@ database storage, background jobs, XLSX export, and email delivery.
   `test-and-build (3.11)`, and `test-and-build (3.12)` so releases
   cannot bypass CI evidence.
 - Vulnerability dismissals that lack an upstream patch must be recorded in
-  `docs/security/dependency-vulnerability-exceptions.md` and re-evaluated
-  on advisory/dependency/release changes.
+  `docs/security/dependency-vulnerability-exceptions.md`, re-evaluated on
+  advisory/dependency/release changes, and moved from Active to Resolved when
+  patched versions are adopted.
 - Local verification remains the fastest pre-PR evidence path.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -21,6 +21,9 @@ Current guardrails include:
 - URL scheme validation (`http`/`https` only)
 - redaction of some sensitive text patterns before outbound requests
 - no runtime dependency on external application databases or auth stacks
+- dependency-vulnerability dismissals are temporary, tracked in
+  `docs/security/dependency-vulnerability-exceptions.md`, and must move from
+  Active to Resolved when a patched version is adopted
 
 ## Supported versions
 

--- a/docs/maintainers/releasing.md
+++ b/docs/maintainers/releasing.md
@@ -5,6 +5,12 @@
 - `main` is green in CI.
 - README, changelog, and version metadata are up to date.
 - The release commit is already merged into `main`.
+- Dependency exception governance is clean:
+  - each active entry in
+    `docs/security/dependency-vulnerability-exceptions.md` is still
+    unpatchable upstream,
+  - any advisory resolved via dependency upgrade has been moved to
+    `Resolved exception entries` in the same change set as the upgrade.
 
 ## Local verification
 
@@ -37,6 +43,16 @@ Branch protection / merge policy:
 - Follow Semantic Versioning.
 - Update `pyproject.toml` version.
 - Move relevant `CHANGELOG.md` items from `Unreleased` into the new version section.
+
+## Dependency-exception release gate
+
+Before tagging:
+
+- Review `docs/security/dependency-vulnerability-exceptions.md`.
+- Confirm no advisory remains in `Active exception entries` if `uv.lock`
+  already contains a patched version for that advisory path.
+- If such an advisory exists, stop release prep and update the dependency and
+  exception register first.
 
 ## Create a release
 

--- a/docs/security/api-security-checklist.md
+++ b/docs/security/api-security-checklist.md
@@ -24,7 +24,14 @@ client in `src/vector_topic_modeling/providers/openai_compat.py`.
 - Re-evaluate each recorded exception whenever one of the following occurs:
   - upstream advisory metadata changes (patched version, severity, scope),
   - dependency graph changes (`uv.lock` refresh or dependency additions),
-  - release cut / branch-protection policy changes.
+  - before each tagged release cut.
+- If a previously dismissed advisory becomes patchable and the repository
+  upgrades to the patched version, close the exception in the same change set:
+  - remove it from active entries in
+    `docs/security/dependency-vulnerability-exceptions.md`,
+  - add it under resolved entries with fixed version (`uv.lock`), PR/commit
+    link, date, and owner,
+  - verify the advisory is no longer tracked as a tolerated dismissal.
 
 ## Not currently applicable
 

--- a/docs/security/dependency-vulnerability-exceptions.md
+++ b/docs/security/dependency-vulnerability-exceptions.md
@@ -12,6 +12,30 @@ is dismissed for `tolerable_risk`, `won't_fix`, or equivalent reasons.
 - Last-reviewed date and owner
 - Explicit re-evaluation triggers
 
+## Exception lifecycle (required)
+
+- **Active exception**: advisory is temporarily dismissed because no patched
+  upstream version is available.
+- **Resolved exception**: a patched upstream version exists and this
+  repository has upgraded to the fixed version.
+
+When an Active exception becomes Resolved, update this document in the same
+change set as the dependency upgrade:
+
+1. Remove the advisory from `## Active exception entries`.
+2. Add the advisory to `## Resolved exception entries` with:
+   - Advisory id / link
+   - Fixed package/version now present in `uv.lock`
+   - Upgrade PR or commit link
+   - Resolution date
+   - Owner
+3. Ensure the corresponding Dependabot alert is no longer left in a dismissed
+   `tolerable_risk` / `won't_fix` state.
+
+## Resolved exception entries
+
+- None currently.
+
 ## Active exception entries
 
 ### GHSA-5239-wwwm-4pmq (CVE-2026-4539)

--- a/tests/test_dependency_security_governance.py
+++ b/tests/test_dependency_security_governance.py
@@ -40,6 +40,8 @@ def test_api_security_checklist_includes_dependency_exception_policy() -> None:
     assert "## Dependency supply-chain checks" in content
     assert ".github/dependabot.yml" in content
     assert "docs/security/dependency-vulnerability-exceptions.md" in content
+    assert "before each tagged release cut" in content
+    assert "add it under resolved entries" in content
 
 
 def test_dependency_exception_register_tracks_current_dismissed_advisory() -> None:
@@ -47,8 +49,18 @@ def test_dependency_exception_register_tracks_current_dismissed_advisory() -> No
 
     assert re.search(r"GHSA-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}", content)
     assert "## Required fields per entry" in content
+    assert "## Exception lifecycle (required)" in content
+    assert "## Resolved exception entries" in content
     assert "## Active exception entries" in content
     assert "Last reviewed:" in content
     assert "Owner:" in content
     assert "tolerable_risk" in content
     assert "re-evaluation triggers" in content
+
+
+def test_release_guide_contains_dependency_exception_gate() -> None:
+    content = read("docs/maintainers/releasing.md")
+
+    assert "## Dependency-exception release gate" in content
+    assert "Resolved exception entries" in content
+    assert "stop release prep" in content


### PR DESCRIPTION
## Summary
- define explicit Active → Resolved lifecycle semantics for dependency vulnerability exceptions
- add release-gate and API checklist requirements so patched advisories are closed in the same change set as dependency upgrades
- extend governance tests to enforce the new canonical wording in security and maintainer docs

## Verification
- `uv run pytest -q`
- `uv run python -m build`
- `uv run python scripts/smoke_installed_cli.py --dist-dir dist --venv-dir .venv-smoke-cli`

Closes #5