### PR TITLE
feat: generalize ingestion for DB columns and JSON payloads

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,8 @@
 
 - Prefer small pure functions and explicit dataclasses.
 - Keep the public API exported from `src/vector_topic_modeling/__init__.py`.
+- Keep source-row ingestion/mapping logic in `src/vector_topic_modeling/ingestion.py`
+  so `pipeline.py` stays model-focused and provider-agnostic.
 
 ## Documentation
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -14,6 +14,7 @@ Last updated: 2026-03-25
 │   ├── text.py
 │   ├── service.py
 │   ├── pipeline.py
+│   ├── ingestion.py
 │   ├── cli.py
 │   └── providers/
 ├── examples/                  # Runnable local examples and sample JSONL
@@ -26,11 +27,13 @@ Last updated: 2026-03-25
 ## Runtime model
 
 1. Caller provides documents or JSONL rows.
-2. `TopicModeler` normalizes text and computes digest keys.
-3. Embeddings are fetched through an injected provider.
-4. Clustering is performed with a dependency-light greedy/adaptive
+2. `ingestion.py` maps raw rows (flat rows, DB column-value rows, or JSON payloads)
+   into `TopicDocument` records and can compose `session_id` from primary-key bundles.
+3. `TopicModeler` normalizes text and computes digest keys.
+4. Embeddings are fetched through an injected provider.
+5. Clustering is performed with a dependency-light greedy/adaptive
    kernel.
-5. Optional session-aware digest selection prevents repeated boilerplate
+6. Optional session-aware digest selection prevents repeated boilerplate
    from dominating.
 
 ## Explicit exclusions

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Standalone embedding-based topic modeling software for vector workflows.
 - dependency-light clustering kernel
 - session-aware representative selection
 - safe text shaping/redaction for embedding input
+- generic ingestion for DB column-value rows and JSON payloads
 - provider-driven `TopicModeler` API
 - JSONL-oriented CLI for standalone runs
 
@@ -82,13 +83,24 @@ See [`examples/`](./examples/) for end-to-end local usage samples.
 Detailed usage and troubleshooting guidance is in
 [`docs/user-manual.md`](./docs/user-manual.md).
 
-## JSONL CLI input shape
+## JSONL CLI input shapes
 
-Each line should be a JSON object containing at least:
+### Legacy flat shape
+
+Each line can contain:
 
 ```json
 {"id":"1","text":"refund duplicate billing","session_id":"s1","question":"...","response":"...","count":1}
 ```
+
+### Generic DB / JSON payload shape
+
+You can also pass arbitrary rows (DB-export style columns or nested JSON payloads)
+and map them with `--ingestion-config`.
+
+Example config: [`examples/ingestion_config_db_columns.json`](./examples/ingestion_config_db_columns.json)
+
+Example rows: [`examples/sample_db_rows.jsonl`](./examples/sample_db_rows.jsonl)
 
 Run the CLI with an OpenAI-compatible embedding endpoint:
 
@@ -100,9 +112,21 @@ vector-topic-modeling cluster input.jsonl \
   --model text-embedding-3-large
 ```
 
+With generic ingestion mapping:
+
+```bash
+vector-topic-modeling cluster examples/sample_db_rows.jsonl \
+  --output topics.json \
+  --ingestion-config examples/ingestion_config_db_columns.json \
+  --base-url https://your-gateway.example.com \
+  --api-key "$LITELLM_API_KEY" \
+  --model text-embedding-3-large
+```
+
 Sample files:
 
 - [`examples/sample_queries.jsonl`](./examples/sample_queries.jsonl)
+- [`examples/sample_db_rows.jsonl`](./examples/sample_db_rows.jsonl)
 - [`examples/cli_openai_compat.sh`](./examples/cli_openai_compat.sh)
 - [`examples/basic_in_memory_provider.py`](./examples/basic_in_memory_provider.py)
 

--- a/docs/agents/README.md
+++ b/docs/agents/README.md
@@ -2,4 +2,6 @@
 
 - Prefer pure-function decoupling over runtime coupling.
 - Use subagents for architecture review when changing boundaries.
+- Keep ingestion adaptation logic in `src/vector_topic_modeling/ingestion.py` so
+  topic-model orchestration stays isolated in `pipeline.py`.
 - Keep runtime adapters isolated under `src/vector_topic_modeling/providers/`.

--- a/docs/user-manual.md
+++ b/docs/user-manual.md
@@ -70,6 +70,17 @@ vector-topic-modeling cluster examples/sample_queries.jsonl \
   --model text-embedding-3-large
 ```
 
+Generic DB/JSON payload ingestion example:
+
+```bash
+vector-topic-modeling cluster examples/sample_db_rows.jsonl \
+  --output topics.json \
+  --ingestion-config examples/ingestion_config_db_columns.json \
+  --base-url "$LITELLM_API_BASE" \
+  --api-key "$LITELLM_API_KEY" \
+  --model text-embedding-3-large
+```
+
 ## 3) JSONL Input / Output
 
 ### 3.1 Input shape
@@ -80,12 +91,19 @@ One JSON object per line:
 {"id":"1","text":"refund duplicate billing","session_id":"s1","question":"...","response":"...","count":1}
 ```
 
+Alternative rows can be DB-style column/value arrays or nested JSON payloads when
+used with `--ingestion-config`.
+
 ### 3.2 Input field behavior
 
 - `id`: preferred identifier; falls back to `document_id`, then row index
 - `text`: defaults to `""` when absent
 - `session_id`, `question`, `response`: optional
 - `count`: defaults to `1`
+
+When `--ingestion-config` sets `session_key_fields`, `session_id` is composed as
+a deterministic primary-key bundle (`pk:{...}`) when no explicit
+`session_id` field is present.
 
 ### 3.3 Output shape (`--output`)
 
@@ -107,10 +125,11 @@ vector-topic-modeling cluster INPUT_JSONL --output OUTPUT_JSON
 | --- | --- | --- | --- |
 | `input_path` | yes | - | Input JSONL file path |
 | `--output` | yes | - | Output JSON path |
-| `--base-url` | runtime-required | - | OpenAI-compatible embedding endpoint URL |
+| `--base-url` | runtime-required | - | OpenAI-compatible embedding URL |
 | `--api-key` | runtime-required | - | API key used for embedding requests |
 | `--model` | no | `text-embedding-3-large` | Embedding model |
 | `--similarity-threshold` | no | `0.85` | Clustering similarity threshold |
+| `--ingestion-config` | no | - | JSON config for generic row ingestion |
 
 Example with stricter threshold:
 
@@ -121,6 +140,33 @@ vector-topic-modeling cluster input.jsonl \
   --api-key "$LITELLM_API_KEY" \
   --model text-embedding-3-large \
   --similarity-threshold 0.90
+```
+
+### 4.1 Ingestion config shape (`--ingestion-config`)
+
+Config keys:
+
+- `id_fields`: ordered candidates for `TopicDocument.id`
+- `text_fields`: ordered candidates for direct text extraction
+- `payload_fields`: ordered candidates for JSON payload fallback
+- `content_fields`: explicit DB column names to concatenate (`field: value`)
+- `session_id_fields`: ordered candidates for explicit `session_id`
+- `session_key_fields`: ordered primary-key columns used to compose `session_id`
+- `column_value_path`: row key containing list-style column/value pairs
+- `column_name_field`, `column_value_field`: keys used inside column/value entries
+
+Example:
+
+```json
+{
+  "id_fields": ["account_id"],
+  "payload_fields": ["payload"],
+  "content_fields": ["query", "answer"],
+  "session_key_fields": ["account_id", "thread_id"],
+  "column_value_path": "columns",
+  "column_name_field": "column",
+  "column_value_field": "value"
+}
 ```
 
 ## 5) Troubleshooting

--- a/examples/ingestion_config_db_columns.json
+++ b/examples/ingestion_config_db_columns.json
@@ -1,0 +1,9 @@
+{
+  "id_fields": ["account_id"],
+  "payload_fields": ["payload"],
+  "content_fields": ["query", "answer"],
+  "session_key_fields": ["account_id", "thread_id"],
+  "column_value_path": "columns",
+  "column_name_field": "column",
+  "column_value_field": "value"
+}

--- a/examples/sample_db_rows.jsonl
+++ b/examples/sample_db_rows.jsonl
@@ -1,0 +1,3 @@
+{"account_id":"acc-100","thread_id":"thr-1","columns":[{"column":"query","value":"3월 청구서에서 중복 결제가 보여요."},{"column":"answer","value":"결제 로그를 확인해 환불 절차를 진행하겠습니다."}]}
+{"account_id":"acc-100","thread_id":"thr-1","payload":{"intent":"billing_refund","locale":"ko-KR","summary":"중복 결제 환불 요청"}}
+{"account_id":"acc-200","thread_id":"thr-9","payload":{"intent":"vpn_timeout","summary":"아침마다 VPN 연결이 끊겨요."}}

--- a/src/vector_topic_modeling/__init__.py
+++ b/src/vector_topic_modeling/__init__.py
@@ -8,6 +8,12 @@ from vector_topic_modeling.pipeline import (
     TopicModelResult,
     TopicModeler,
 )
+from vector_topic_modeling.ingestion import (
+    TopicDocumentIngestionConfig,
+    load_ingestion_config,
+    load_jsonl_topic_documents,
+    topic_document_from_row,
+)
 from vector_topic_modeling.providers.openai_compat import (
     OpenAICompatConfig,
     OpenAICompatEmbeddingProvider,
@@ -16,10 +22,14 @@ from vector_topic_modeling.providers.openai_compat import (
 __all__ = [
     "OpenAICompatConfig",
     "OpenAICompatEmbeddingProvider",
+    "TopicDocumentIngestionConfig",
     "Topic",
     "TopicAssignment",
     "TopicDocument",
     "TopicModelConfig",
     "TopicModelResult",
     "TopicModeler",
+    "load_ingestion_config",
+    "load_jsonl_topic_documents",
+    "topic_document_from_row",
 ]

--- a/src/vector_topic_modeling/cli.py
+++ b/src/vector_topic_modeling/cli.py
@@ -6,6 +6,10 @@ import argparse
 import json
 from pathlib import Path
 
+from vector_topic_modeling.ingestion import (
+    load_ingestion_config,
+    load_jsonl_topic_documents,
+)
 from vector_topic_modeling.pipeline import TopicDocument, TopicModelConfig, TopicModeler
 from vector_topic_modeling.providers.openai_compat import (
     OpenAICompatConfig,
@@ -28,6 +32,7 @@ def build_parser() -> argparse.ArgumentParser:
     cluster.add_argument("--api-key")
     cluster.add_argument("--model", default="text-embedding-3-large")
     cluster.add_argument("--similarity-threshold", type=float, default=0.85)
+    cluster.add_argument("--ingestion-config")
     return parser
 
 
@@ -37,7 +42,10 @@ def main(argv: list[str] | None = None) -> int:
         raise ValueError(f"Unsupported command: {args.command}")
     if not args.base_url or not args.api_key:
         raise ValueError("cluster requires --base-url and --api-key")
-    docs = _load_jsonl(Path(args.input_path))
+    docs = _load_jsonl(
+        Path(args.input_path),
+        ingestion_config_path=args.ingestion_config,
+    )
     provider = OpenAICompatEmbeddingProvider(
         OpenAICompatConfig(
             base_url=args.base_url, api_key=args.api_key, model=args.model
@@ -67,20 +75,14 @@ def main(argv: list[str] | None = None) -> int:
     return 0
 
 
-def _load_jsonl(path: Path) -> list[TopicDocument]:
-    documents: list[TopicDocument] = []
-    for line in path.read_text(encoding="utf-8").splitlines():
-        if not line.strip():
-            continue
-        row = json.loads(line)
-        documents.append(
-            TopicDocument(
-                id=str(row.get("id") or row.get("document_id") or len(documents)),
-                text=str(row.get("text") or ""),
-                session_id=row.get("session_id"),
-                question=row.get("question"),
-                response=row.get("response"),
-                count=int(row.get("count") or 1),
-            )
-        )
-    return documents
+def _load_jsonl(
+    path: Path,
+    *,
+    ingestion_config_path: str | None = None,
+) -> list[TopicDocument]:
+    config = (
+        load_ingestion_config(Path(ingestion_config_path))
+        if ingestion_config_path
+        else load_ingestion_config(None)
+    )
+    return load_jsonl_topic_documents(path, config=config)

--- a/src/vector_topic_modeling/ingestion.py
+++ b/src/vector_topic_modeling/ingestion.py
@@ -1,0 +1,269 @@
+"""Generic row ingestion helpers for topic modeling inputs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+from pathlib import Path
+from typing import Any, Mapping
+
+from vector_topic_modeling.pipeline import TopicDocument
+from vector_topic_modeling.text import build_qa_pair_text, normalize_text
+
+
+@dataclass(frozen=True)
+class TopicDocumentIngestionConfig:
+    id_fields: tuple[str, ...] = ("id", "document_id")
+    text_fields: tuple[str, ...] = ("text",)
+    payload_fields: tuple[str, ...] = ("payload", "json_payload", "body")
+    content_fields: tuple[str, ...] = ()
+    question_fields: tuple[str, ...] = ("question",)
+    response_fields: tuple[str, ...] = ("response",)
+    session_id_fields: tuple[str, ...] = ("session_id",)
+    session_key_fields: tuple[str, ...] = ()
+    count_field: str = "count"
+    column_value_path: str | None = None
+    column_name_field: str = "column"
+    column_value_field: str = "value"
+    max_text_chars: int = 4000
+
+
+def load_ingestion_config(path: Path | None) -> TopicDocumentIngestionConfig:
+    if path is None:
+        return TopicDocumentIngestionConfig()
+    parsed = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(parsed, dict):
+        raise ValueError("ingestion config must be a JSON object")
+    return TopicDocumentIngestionConfig(
+        id_fields=_to_field_tuple(
+            parsed.get("id_fields"), fallback=("id", "document_id")
+        ),
+        text_fields=_to_field_tuple(parsed.get("text_fields"), fallback=("text",)),
+        payload_fields=_to_field_tuple(
+            parsed.get("payload_fields"),
+            fallback=("payload", "json_payload", "body"),
+        ),
+        content_fields=_to_field_tuple(parsed.get("content_fields"), fallback=()),
+        question_fields=_to_field_tuple(
+            parsed.get("question_fields"), fallback=("question",)
+        ),
+        response_fields=_to_field_tuple(
+            parsed.get("response_fields"), fallback=("response",)
+        ),
+        session_id_fields=_to_field_tuple(
+            parsed.get("session_id_fields"), fallback=("session_id",)
+        ),
+        session_key_fields=_to_field_tuple(
+            parsed.get("session_key_fields"), fallback=()
+        ),
+        count_field=str(parsed.get("count_field") or "count"),
+        column_value_path=_opt_text(parsed.get("column_value_path")),
+        column_name_field=str(parsed.get("column_name_field") or "column"),
+        column_value_field=str(parsed.get("column_value_field") or "value"),
+        max_text_chars=max(1, int(parsed.get("max_text_chars") or 4000)),
+    )
+
+
+def load_jsonl_topic_documents(
+    path: Path,
+    *,
+    config: TopicDocumentIngestionConfig | None = None,
+) -> list[TopicDocument]:
+    effective = config or TopicDocumentIngestionConfig()
+    documents: list[TopicDocument] = []
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        row = json.loads(line)
+        if not isinstance(row, dict):
+            raise ValueError("each JSONL line must be a JSON object")
+        documents.append(
+            topic_document_from_row(row, row_index=len(documents), config=effective)
+        )
+    return documents
+
+
+def topic_document_from_row(
+    row: Mapping[str, object],
+    *,
+    row_index: int,
+    config: TopicDocumentIngestionConfig | None = None,
+) -> TopicDocument:
+    effective = config or TopicDocumentIngestionConfig()
+    materialized = _materialize_column_value_fields(row=row, config=effective)
+    question = _first_non_empty(materialized, effective.question_fields)
+    response = _first_non_empty(materialized, effective.response_fields)
+    text = _resolve_text(
+        row=materialized,
+        question=question,
+        response=response,
+        config=effective,
+    )
+    session_id = _resolve_session_id(materialized, config=effective)
+    document_id = _resolve_document_id(
+        row=materialized,
+        row_index=row_index,
+        config=effective,
+    )
+    return TopicDocument(
+        id=document_id,
+        text=text,
+        session_id=session_id,
+        question=question or None,
+        response=response or None,
+        count=_coerce_count(materialized.get(effective.count_field), default=1),
+    )
+
+
+def _resolve_document_id(
+    *,
+    row: Mapping[str, object],
+    row_index: int,
+    config: TopicDocumentIngestionConfig,
+) -> str:
+    explicit = _first_non_empty(row, config.id_fields)
+    return explicit if explicit else str(row_index)
+
+
+def _resolve_session_id(
+    row: Mapping[str, object],
+    *,
+    config: TopicDocumentIngestionConfig,
+) -> str | None:
+    explicit = _first_non_empty(row, config.session_id_fields)
+    if explicit:
+        return explicit
+    if not config.session_key_fields:
+        return None
+    bundle: dict[str, str] = {}
+    for field in config.session_key_fields:
+        value = _stringify(row.get(field)).strip()
+        if not value:
+            return None
+        bundle[field] = value
+    return "pk:" + json.dumps(
+        bundle,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+
+
+def _resolve_text(
+    *,
+    row: Mapping[str, object],
+    question: str,
+    response: str,
+    config: TopicDocumentIngestionConfig,
+) -> str:
+    direct_text = _first_non_empty(row, config.text_fields)
+    if direct_text:
+        return normalize_text(direct_text, max_chars=config.max_text_chars)
+    if config.content_fields:
+        pieces = []
+        for field in config.content_fields:
+            raw = row.get(field)
+            rendered = _stringify(raw).strip()
+            if rendered:
+                pieces.append(f"{field}: {rendered}")
+        if pieces:
+            return normalize_text("\n".join(pieces), max_chars=config.max_text_chars)
+    payload_text = _first_non_empty_payload(row, config.payload_fields)
+    if payload_text:
+        return normalize_text(payload_text, max_chars=config.max_text_chars)
+    if question or response:
+        return build_qa_pair_text(
+            question,
+            response,
+            max_chars=config.max_text_chars,
+        )
+    return normalize_text(
+        json.dumps(row, ensure_ascii=False, sort_keys=True, default=str),
+        max_chars=config.max_text_chars,
+    )
+
+
+def _materialize_column_value_fields(
+    *,
+    row: Mapping[str, object],
+    config: TopicDocumentIngestionConfig,
+) -> dict[str, object]:
+    out = dict(row)
+    source_key = config.column_value_path
+    if not source_key:
+        return out
+    raw = out.get(source_key)
+    if not isinstance(raw, list):
+        return out
+    for item in raw:
+        if not isinstance(item, dict):
+            continue
+        column_name = _stringify(item.get(config.column_name_field)).strip()
+        if not column_name:
+            continue
+        out[column_name] = item.get(config.column_value_field)
+    return out
+
+
+def _first_non_empty(row: Mapping[str, object], fields: tuple[str, ...]) -> str:
+    for field in fields:
+        rendered = _stringify(row.get(field)).strip()
+        if rendered:
+            return rendered
+    return ""
+
+
+def _first_non_empty_payload(row: Mapping[str, object], fields: tuple[str, ...]) -> str:
+    for field in fields:
+        value = row.get(field)
+        rendered = _stringify(value).strip()
+        if rendered:
+            return rendered
+    return ""
+
+
+def _coerce_count(value: Any, *, default: int) -> int:
+    if isinstance(value, bool):
+        return default
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    if isinstance(value, str):
+        try:
+            return int(value)
+        except ValueError:
+            return default
+    return default
+
+
+def _stringify(value: object) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return str(value)
+    if isinstance(value, (list, dict)):
+        return json.dumps(value, ensure_ascii=False, sort_keys=True, default=str)
+    return str(value)
+
+
+def _to_field_tuple(value: object, *, fallback: tuple[str, ...]) -> tuple[str, ...]:
+    if value is None:
+        return fallback
+    if isinstance(value, str):
+        stripped = value.strip()
+        return (stripped,) if stripped else fallback
+    if isinstance(value, list):
+        fields = tuple(str(item).strip() for item in value if str(item).strip())
+        return fields if fields else fallback
+    return fallback
+
+
+def _opt_text(value: object) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,6 +12,7 @@ def test_build_parser_supports_cluster_command() -> None:
     assert args.command == "cluster"
     assert args.input_path == "input.jsonl"
     assert args.output_path == "topics.json"
+    assert args.ingestion_config is None
 
 
 def test_cli_cluster_writes_output(monkeypatch, tmp_path: Path) -> None:
@@ -50,3 +51,64 @@ def test_cli_cluster_writes_output(monkeypatch, tmp_path: Path) -> None:
     assert rc == 0
     assert payload["topics"]
     assert payload["assignments"][0]["document_id"] == "1"
+
+
+def test_cli_cluster_supports_generic_ingestion_config(
+    monkeypatch, tmp_path: Path
+) -> None:
+    from vector_topic_modeling import cli
+
+    input_path = tmp_path / "input.jsonl"
+    output_path = tmp_path / "topics.json"
+    config_path = tmp_path / "ingestion.json"
+
+    input_path.write_text(
+        json.dumps(
+            {
+                "pk_a": "account-1",
+                "pk_b": "thread-2",
+                "payload": {"text": "generic payload topic text"},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    config_path.write_text(
+        json.dumps(
+            {
+                "id_fields": ["pk_a"],
+                "payload_fields": ["payload"],
+                "session_key_fields": ["pk_a", "pk_b"],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    class FakeProvider:
+        def __init__(self, config) -> None:
+            self.config = config
+
+        def embed(self, texts: list[str]) -> list[list[float]]:
+            return [[1.0, 0.0] for _ in texts]
+
+    monkeypatch.setattr(cli, "OpenAICompatEmbeddingProvider", FakeProvider)
+
+    rc = cli.main(
+        [
+            "cluster",
+            str(input_path),
+            "--output",
+            str(output_path),
+            "--ingestion-config",
+            str(config_path),
+            "--base-url",
+            "https://example.com",
+            "--api-key",
+            "key",
+        ]
+    )
+
+    payload = json.loads(output_path.read_text(encoding="utf-8"))
+    assert rc == 0
+    assert payload["topics"]
+    assert payload["assignments"][0]["document_id"] == "account-1"

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+from datetime import datetime
+import json
+from pathlib import Path
+
+import pytest
+
+from vector_topic_modeling.ingestion import (
+    TopicDocumentIngestionConfig,
+    load_ingestion_config,
+    load_jsonl_topic_documents,
+    topic_document_from_row,
+)
+
+
+def test_topic_document_from_row_preserves_legacy_defaults() -> None:
+    row = {
+        "id": "doc-1",
+        "text": "refund duplicate billing",
+        "session_id": "session-1",
+        "question": "q",
+        "response": "r",
+        "count": 3,
+    }
+
+    doc = topic_document_from_row(row, row_index=0)
+
+    assert doc.id == "doc-1"
+    assert doc.text == "refund duplicate billing"
+    assert doc.session_id == "session-1"
+    assert doc.question == "q"
+    assert doc.response == "r"
+    assert doc.count == 3
+
+
+def test_topic_document_from_row_uses_payload_when_text_missing() -> None:
+    row = {
+        "id": "doc-2",
+        "payload": {"ticket": {"intent": "billing_refund", "locale": "ko-KR"}},
+    }
+
+    doc = topic_document_from_row(row, row_index=0)
+
+    assert "billing_refund" in doc.text
+    assert "ticket" in doc.text
+
+
+def test_topic_document_from_row_supports_db_column_value_input() -> None:
+    config = TopicDocumentIngestionConfig(
+        content_fields=("query", "answer"),
+        column_value_path="columns",
+    )
+    row = {
+        "id": "doc-3",
+        "columns": [
+            {"column": "query", "value": "왜 이중 결제가 되었나요?"},
+            {"column": "answer", "value": "영수증을 확인한 뒤 환불을 도와드릴게요."},
+        ],
+    }
+
+    doc = topic_document_from_row(row, row_index=0, config=config)
+
+    assert "query:" in doc.text
+    assert "answer:" in doc.text
+
+
+def test_topic_document_from_row_builds_session_id_from_primary_key_bundle() -> None:
+    config = TopicDocumentIngestionConfig(session_key_fields=("tenant_id", "thread_id"))
+    row = {
+        "id": "doc-4",
+        "tenant_id": "t-1",
+        "thread_id": "th-9",
+        "text": "session key bundle example",
+    }
+
+    doc = topic_document_from_row(row, row_index=0, config=config)
+
+    assert doc.session_id is not None
+    assert doc.session_id.startswith("pk:")
+    assert '"tenant_id":"t-1"' in doc.session_id
+    assert '"thread_id":"th-9"' in doc.session_id
+
+
+def test_load_jsonl_topic_documents_accepts_config_file(tmp_path: Path) -> None:
+    input_path = tmp_path / "input.jsonl"
+    config_path = tmp_path / "ingestion.json"
+
+    input_path.write_text(
+        json.dumps(
+            {
+                "pk_a": "A",
+                "pk_b": "B",
+                "payload": {"message": "db payload text"},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    config_path.write_text(
+        json.dumps(
+            {
+                "session_key_fields": ["pk_a", "pk_b"],
+                "payload_fields": ["payload"],
+                "id_fields": ["pk_a"],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    config = load_ingestion_config(config_path)
+    docs = load_jsonl_topic_documents(input_path, config=config)
+
+    assert len(docs) == 1
+    assert docs[0].id == "A"
+    assert docs[0].session_id is not None
+    assert "db payload text" in docs[0].text
+
+
+def test_load_ingestion_config_rejects_non_object_json(tmp_path: Path) -> None:
+    config_path = tmp_path / "ingestion.json"
+    config_path.write_text(json.dumps(["bad"]), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="JSON object"):
+        load_ingestion_config(config_path)
+
+
+def test_load_jsonl_topic_documents_rejects_non_object_rows(tmp_path: Path) -> None:
+    input_path = tmp_path / "input.jsonl"
+    input_path.write_text(json.dumps(["bad"]) + "\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="JSON object"):
+        load_jsonl_topic_documents(input_path)
+
+
+def test_topic_document_from_row_accepts_non_json_serializable_payload_values() -> None:
+    row = {
+        "id": "doc-x",
+        "payload": {"ts": datetime(2026, 1, 1, 0, 0)},
+    }
+
+    doc = topic_document_from_row(row, row_index=0)
+
+    assert "2026-01-01" in doc.text


### PR DESCRIPTION
## Summary
- add a new `ingestion.py` adapter that converts generic row shapes (flat fields, DB column/value arrays, and nested payloads) into `TopicDocument`
- support deterministic `session_id` composition from configured primary-key bundles when explicit session ids are missing
- extend CLI with `--ingestion-config`, add regression tests/examples, and update architecture/user docs to reflect the new ingestion layer

## Verification
- `uv run pytest -q`
- `uv run python -m build`
- `uv run python scripts/smoke_installed_cli.py --dist-dir dist --venv-dir .venv-smoke-cli`
- `lint_by_filetype` (markdownlint, black, ruff, mypy) all green