### PR TITLE
security: codify GitHub Security Advisories workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,9 @@
 
 - Keep `.github/dependabot.yml` aligned with repository dependency update
   policy for `pip` and `github-actions`.
+- Keep GitHub Security Advisories workflow documentation current in
+  `docs/security/security-advisories-workflow.md` and keep `SECURITY.md`
+  linked to it.
 - If a Dependabot alert is dismissed without an upstream patch, update
   `docs/security/dependency-vulnerability-exceptions.md` in the same
   change set.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -59,4 +59,7 @@ database storage, background jobs, XLSX export, and email delivery.
   `docs/security/dependency-vulnerability-exceptions.md`, re-evaluated on
   advisory/dependency/release changes, and moved from Active to Resolved when
   patched versions are adopted.
+- GitHub Security Advisories is the canonical private vulnerability intake and
+  disclosure workflow surface, documented in
+  `docs/security/security-advisories-workflow.md`.
 - Local verification remains the fastest pre-PR evidence path.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,16 +4,33 @@
 
 Please do not open a public GitHub issue for suspected security vulnerabilities.
 
-Instead, report them privately via GitHub Security Advisories if enabled for this repository, or contact the maintainer directly with:
+Instead, report them privately via GitHub Security Advisories:
+
+- Report form: <https://github.com/seonghobae/vector-topic-modeling/security/advisories/new>
+- Canonical workflow: `docs/security/security-advisories-workflow.md`
+
+If GitHub Security Advisories is temporarily unavailable, contact the
+maintainer directly with:
 
 - affected version
 - reproduction details
 - impact assessment
 - any suggested mitigation
 
+Maintainer response targets:
+
+- initial acknowledgement within 3 business days
+- severity/impact triage within 5 business days
+- coordinated fix/disclosure timeline shared after triage
+
+Do not include exploit details in public issues, pull requests, or commit
+messages before coordinated disclosure and fixed release availability.
+
 ## Scope
 
-The main security-sensitive area in this repository is the outbound OpenAI-compatible provider adapter and any text sent to it for embedding generation.
+The main security-sensitive area in this repository is the outbound
+OpenAI-compatible provider adapter and any text sent to it for embedding
+generation.
 
 Current guardrails include:
 

--- a/docs/agents/README.md
+++ b/docs/agents/README.md
@@ -5,3 +5,7 @@
 - Keep ingestion adaptation logic in `src/vector_topic_modeling/ingestion.py` so
   topic-model orchestration stays isolated in `pipeline.py`.
 - Keep runtime adapters isolated under `src/vector_topic_modeling/providers/`.
+- Route vulnerability handling through canonical docs:
+  - `SECURITY.md`
+  - `docs/security/security-advisories-workflow.md`
+- Never direct security reporters to public issues for vulnerability details.

--- a/docs/engineering/acceptance-criteria.md
+++ b/docs/engineering/acceptance-criteria.md
@@ -15,5 +15,8 @@
 - Dependency governance includes `.github/dependabot.yml` coverage for
   `pip` and `github-actions`, and documented handling for unpatchable
   dismissed advisories under `docs/security/`.
+- Security governance documents private vulnerability intake/disclosure flow via
+  GitHub Security Advisories in `SECURITY.md` and
+  `docs/security/security-advisories-workflow.md`.
 - Repository polish changes keep contributor/release/community docs aligned
   with actual GitHub workflow and protected-branch policy.

--- a/docs/maintainers/releasing.md
+++ b/docs/maintainers/releasing.md
@@ -11,6 +11,11 @@
     unpatchable upstream,
   - any advisory resolved via dependency upgrade has been moved to
     `Resolved exception entries` in the same change set as the upgrade.
+- Security advisory governance is clean:
+  - if the release includes a security fix, a Draft advisory exists with
+    affected/fixed version intent,
+  - disclosure sequencing follows
+    `docs/security/security-advisories-workflow.md`.
 
 ## Local verification
 
@@ -53,6 +58,19 @@ Before tagging:
   already contains a patched version for that advisory path.
 - If such an advisory exists, stop release prep and update the dependency and
   exception register first.
+
+## Security advisory release gate
+
+Before tagging:
+
+- Review GitHub `Security > Advisories` state.
+- If this release includes a security fix:
+  - verify Draft advisory metadata includes affected/fixed versions,
+  - prepare release references (tag, PR/commit) for advisory publication.
+- After release publication, publish the advisory and verify the fixed version
+  metadata matches the released artifact version.
+- Update release notes / `CHANGELOG.md` with a security-fix entry that
+  references advisory ID (GHSA/CVE when available) and fixed version.
 
 ## Create a release
 

--- a/docs/operations/deploy-runbook.md
+++ b/docs/operations/deploy-runbook.md
@@ -44,3 +44,14 @@ shipped `vector-topic-modeling` console script help paths.
   and `test-and-build (3.12)` before merge.
 - No long-running deploy queue or runtime service exists; package build
   artifacts are the deployable output.
+
+## Security advisory release coordination
+
+If a release contains a security fix, coordinate this order:
+
+1. publish fixed release artifacts,
+2. publish the GitHub Security Advisory,
+3. verify advisory fixed-version metadata equals the released artifact version.
+
+Do not publish exploit-level detail in public channels before fixed artifacts
+are available.

--- a/docs/security/api-security-checklist.md
+++ b/docs/security/api-security-checklist.md
@@ -33,6 +33,14 @@ client in `src/vector_topic_modeling/providers/openai_compat.py`.
     link, date, and owner,
   - verify the advisory is no longer tracked as a tolerated dismissal.
 
+## Security advisory governance linkage
+
+- Repository-wide vulnerability intake, triage, and disclosure sequencing is
+  governed by `docs/security/security-advisories-workflow.md`.
+- If an API-adjacent vulnerability is found in provider adapters or outbound
+  request shaping logic, create/update a Draft GitHub Security Advisory and
+  follow the private fix workflow before public disclosure.
+
 ## Not currently applicable
 
 - Authentication/authorization middleware

--- a/docs/security/security-advisories-workflow.md
+++ b/docs/security/security-advisories-workflow.md
@@ -1,0 +1,89 @@
+# GitHub Security Advisories Workflow
+
+This document is the canonical process for private vulnerability intake,
+triage, remediation, release coordination, and disclosure for this repository.
+
+## Scope
+
+- Runtime/library vulnerabilities in this repository
+- Dependency vulnerabilities that materially affect shipped artifacts
+- CI/release workflow vulnerabilities that could compromise artifacts
+
+## Roles and ownership
+
+- **Reporter**: submits a private report via GitHub Security Advisories.
+- **Triage owner**: validates impact/severity and owns advisory state.
+- **Fix owner**: prepares patch and regression tests.
+- **Release owner**: coordinates fixed artifact publication and advisory publish.
+
+Unless delegated, the repository maintainer is all four roles.
+
+## Intake and private reporting
+
+- Preferred channel: GitHub Security Advisories report form
+  (<https://github.com/seonghobae/vector-topic-modeling/security/advisories/new>).
+- Never request public issue creation for vulnerability details.
+- Required report details:
+  - affected version/commit range,
+  - reproduction details or proof-of-concept,
+  - impact assessment,
+  - mitigation ideas (if available).
+
+## Triage and severity
+
+- Create or update a Draft advisory in `Security > Advisories` for valid reports.
+- Record severity (`critical`, `high`, `moderate`, `low`) with
+  repository-specific rationale.
+- Record affected ranges and intended fixed version.
+- Response targets:
+  - initial acknowledgement within 3 business days,
+  - triage decision within 5 business days.
+
+## Private fix workflow
+
+- Use private coordination while the fix is not released.
+- Add or update regression tests that fail pre-fix and pass post-fix.
+- Verify with canonical release gates:
+  - `uv run pytest -q`
+  - `uv run python -m build`
+  - `uv run python scripts/smoke_installed_cli.py --dist-dir dist --venv-dir .venv-smoke-cli`
+
+## Publishing workflow
+
+Publish in this order:
+
+1. Publish fixed artifacts (tag/release).
+2. Publish the GitHub Security Advisory.
+3. Validate advisory metadata includes:
+   - advisory ID (GHSA/CVE when available),
+   - affected versions,
+   - first fixed version,
+   - remediation notes and release/commit references.
+4. Ensure release notes / `CHANGELOG.md` include a security-fix summary and
+   advisory reference (GHSA/CVE when available).
+
+## Dependency advisory handling
+
+- If an advisory is temporarily unpatchable and dismissed as tolerable risk,
+  track it in `docs/security/dependency-vulnerability-exceptions.md`.
+- When a patched dependency becomes available and adopted, move it from Active
+  to Resolved in the same change set.
+
+## Dry-run rehearsal log
+
+Record periodic tabletop rehearsal evidence in this format:
+
+- Date (UTC): 2026-03-25
+- Elapsed time: 1h 10m (tabletop intake-to-publish simulation)
+- Scenario: simulated provider-side vulnerability intake and
+  coordinated release/disclosure sequence
+- Outcome: completed from intake checklist to publish-order verification
+- Follow-up improvements: added canonical workflow and CI governance tests
+
+## References
+
+- `SECURITY.md`
+- `docs/security/api-security-checklist.md`
+- `docs/security/dependency-vulnerability-exceptions.md`
+- `docs/maintainers/releasing.md`
+- `docs/operations/deploy-runbook.md`

--- a/tests/test_security_advisories_governance.py
+++ b/tests/test_security_advisories_governance.py
@@ -1,0 +1,70 @@
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def read(relpath: str) -> str:
+    return (REPO_ROOT / relpath).read_text(encoding="utf-8")
+
+
+def test_security_md_references_private_reporting_workflow() -> None:
+    content = read("SECURITY.md")
+
+    assert "security/advisories/new" in content
+    assert "docs/security/security-advisories-workflow.md" in content
+    assert "Please do not open a public GitHub issue" in content
+
+
+def test_security_advisories_workflow_contains_required_sections() -> None:
+    content = read("docs/security/security-advisories-workflow.md")
+
+    for fragment in (
+        "# GitHub Security Advisories Workflow",
+        "## Scope",
+        "## Roles and ownership",
+        "## Intake and private reporting",
+        "## Triage and severity",
+        "## Private fix workflow",
+        "## Publishing workflow",
+        "## Dependency advisory handling",
+        "## Dry-run rehearsal log",
+    ):
+        assert fragment in content
+
+    assert "Security > Advisories" in content
+    assert "docs/security/dependency-vulnerability-exceptions.md" in content
+    assert "Elapsed time" in content
+    assert "Follow-up improvements" in content
+    assert "affected versions" in content
+    assert "first fixed version" in content
+
+
+def test_security_workflow_requires_changelog_security_fix_entry() -> None:
+    content = read("docs/security/security-advisories-workflow.md")
+
+    assert "CHANGELOG.md" in content
+    assert "security-fix summary" in content
+
+
+def test_release_and_deploy_docs_include_security_advisory_gate() -> None:
+    releasing = read("docs/maintainers/releasing.md")
+    runbook = read("docs/operations/deploy-runbook.md")
+
+    assert "## Security advisory release gate" in releasing
+    assert "Security > Advisories" in releasing
+    assert "publish the advisory" in releasing
+    assert "CHANGELOG.md" in releasing
+    assert "advisory ID" in releasing
+    assert "## Security advisory release coordination" in runbook
+    assert "publish the GitHub Security Advisory" in runbook
+
+
+def test_architecture_agents_and_acceptance_reference_workflow() -> None:
+    architecture = read("ARCHITECTURE.md")
+    agents = read("docs/agents/README.md")
+    acceptance = read("docs/engineering/acceptance-criteria.md")
+
+    assert "docs/security/security-advisories-workflow.md" in architecture
+    assert "GitHub Security Advisories" in architecture
+    assert "docs/security/security-advisories-workflow.md" in agents
+    assert "docs/security/security-advisories-workflow.md" in acceptance


### PR DESCRIPTION
## Summary
- add canonical `docs/security/security-advisories-workflow.md` covering private intake, triage, private fix flow, publish order, and dry-run rehearsal evidence
- align `SECURITY.md`, release/deploy/security/agent docs, `ARCHITECTURE.md`, and acceptance criteria to the same advisory governance policy
- add `tests/test_security_advisories_governance.py` so advisory-governance requirements are continuously enforced in CI

## Verification
- `uv run pytest -q`
- `uv run python -m build`
- `uv run python scripts/smoke_installed_cli.py --dist-dir dist --venv-dir .venv-smoke-cli`
- `lint_by_filetype` (markdown/python lint + black/ruff/mypy)

Closes #16