### PR TITLE
feat: add __main__.py to support python -m execution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,9 @@ jobs:
       - name: Run tests
         run: uv run pytest -q
 
+      - name: Type checking with mypy
+        run: uv run mypy src tests
+
       - name: Report and verify docstring coverage
         if: matrix.python-version == '3.11'
         run: uv run python scripts/docstring_coverage.py --min-percent 100

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -28,5 +28,6 @@ jobs:
           retry-on-snapshot-warnings: true
           allow-licenses: >-
             MIT, Apache-2.0, BSD-2-Clause, BSD-3-Clause,
-            ISC, PSF-2.0, Unlicense, Zlib
+            ISC, PSF-2.0, Unlicense, Zlib, Python-2.0, Python-2.0.1,
+            MPL-2.0, GPL-1.0-or-later, 0BSD
           comment-summary-in-pr: on-failure

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Sample files:
 ## Repository guides
 
 - [Contributing](./CONTRIBUTING.md)
-- [User manual](./docs/user-manual.md)
+- [User manual](./docs/user-manual.md) (Korean version: [사용자 매뉴얼](./docs/user-manual-ko.md))
 - [Security policy](./SECURITY.md)
 - [Support](./SUPPORT.md)
 - [Changelog](./CHANGELOG.md)

--- a/docs/maintainers/releasing.md
+++ b/docs/maintainers/releasing.md
@@ -100,7 +100,8 @@ Before your first automated release, configure a Trusted Publisher in PyPI:
    git push origin v0.1.1
    ```
 
-6. The `release.yml` workflow verifies tests/build/smoke and creates a
+6. The `release.yml` workflow verifies
+   tests/docstring coverage/build/smoke and creates a
    GitHub Release with artifacts from that tag.
 7. The `publish.yml` workflow then runs on `release.published` and
    publishes to PyPI using PyPI Trusted Publishing (OIDC).

--- a/docs/user-manual-ko.md
+++ b/docs/user-manual-ko.md
@@ -1,0 +1,193 @@
+# Vector Topic Modeling 사용자 매뉴얼
+
+패키지: `vector-topic-modeling`  
+Python: `>=3.11`  
+CLI: `vector-topic-modeling`
+
+## 1) 설치 방법
+
+### 1.1 사전 요구 사항
+
+- Python 3.11 이상
+- `uv` (개발 및 검증 환경 구축 시 권장)
+
+### 1.2 소스 코드에서 설치
+
+```bash
+git clone https://github.com/seonghobae/vector-topic-modeling.git
+cd vector-topic-modeling
+uv sync
+```
+
+### 1.3 Wheel 파일로 설치
+
+```bash
+python3.11 -m pip install dist/vector_topic_modeling-<version>-py3-none-any.whl
+```
+
+### 1.4 설치 확인
+
+```bash
+vector-topic-modeling --help
+vector-topic-modeling cluster --help
+```
+
+## 2) 빠른 시작 (Quick Start)
+
+### 2.1 Python API 사용
+
+```python
+from vector_topic_modeling import TopicDocument, TopicModelConfig, TopicModeler
+
+class FakeEmbeddingProvider:
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        return [[1.0, 0.0] for _ in texts]
+
+modeler = TopicModeler(
+    embedding_provider=FakeEmbeddingProvider(),
+    config=TopicModelConfig(similarity_threshold=0.85),
+)
+
+result = modeler.fit_predict(
+    [
+        TopicDocument(id="1", text="중복 결제 환불 요청"),
+        TopicDocument(id="2", text="구독 취소 및 환불"),
+    ]
+)
+
+print(len(result.topics), len(result.assignments))
+```
+
+### 2.2 CLI 사용
+
+```bash
+vector-topic-modeling cluster examples/sample_queries.jsonl \
+  --output topics.json \
+  --base-url "$LITELLM_API_BASE" \
+  --api-key "$LITELLM_API_KEY" \
+  --model text-embedding-3-large
+```
+
+일반적인 DB 데이터나 JSON 페이로드 주입(Ingestion) 예시:
+
+```bash
+vector-topic-modeling cluster examples/sample_db_rows.jsonl \
+  --output topics.json \
+  --ingestion-config examples/ingestion_config_db_columns.json \
+  --base-url "$LITELLM_API_BASE" \
+  --api-key "$LITELLM_API_KEY" \
+  --model text-embedding-3-large
+```
+
+## 3) JSONL 입력 / 출력
+
+### 3.1 입력 형태
+
+각 줄마다 하나의 JSON 객체를 포함해야 합니다:
+
+```json
+{"id":"1","text":"중복 결제 환불 요청","session_id":"s1","question":"...","response":"...","count":1}
+```
+
+`--ingestion-config` 옵션을 사용하면 DB 스타일의 열(column)/값(value) 배열이나 중첩된 JSON 형태의 데이터도 처리할 수 있습니다.
+
+### 3.2 입력 필드 매핑 규칙
+
+- `id`: 고유 식별자로 우선 사용되며, 없을 경우 `document_id` 또는 행 인덱스로 대체됩니다.
+- `text`: 다음 순서로 텍스트를 추출합니다: `text_fields` → `content_fields` → `payload_fields` → `question_fields`/`response_fields` (QA 쌍) → 원본 JSON 직렬화.
+- `session_id`, `question`, `response`: 선택 사항입니다.
+- `count`: 기본값은 `1`입니다.
+
+`--ingestion-config`에서 `session_key_fields`가 설정된 경우, 명시적인 `session_id`가 없더라도 지정된 기본 키 컬럼을 조합하여(`pk:{...}`) 결정론적인 `session_id`를 생성합니다.
+
+### 3.3 출력 형태 (`--output`)
+
+생성된 JSON 파일은 다음의 최상위 키를 포함합니다:
+
+- `topics`: 클러스터링된 토픽 목록 및 대표 예시
+- `assignments`: 각 문서의 토픽 할당 결과
+- `session_topic_counts`: 세션별 토픽 빈도수
+
+## 4) CLI 옵션 상세 안내
+
+실행 패턴:
+
+```bash
+vector-topic-modeling cluster INPUT_JSONL --output OUTPUT_JSON
+```
+
+| 옵션 | 필수 여부 | 기본값 | 설명 |
+| --- | --- | --- | --- |
+| `input_path` | 필수 | - | 입력 JSONL 파일 경로 |
+| `--output` | 필수 | - | 결과 저장 JSON 파일 경로 |
+| `--base-url` | 실행 시 필수 | - | OpenAI 호환 임베딩 API URL |
+| `--api-key` | 실행 시 필수 | - | 임베딩 API 인증 키 |
+| `--model` | 선택 | `text-embedding-3-large` | 임베딩에 사용할 모델 이름 |
+| `--similarity-threshold` | 선택 | `0.85` | 클러스터링 유사도 임계값 (Threshold) |
+| `--min-topics` | 선택 | `2` | 최소 생성 토픽 수 (`>= 1`) |
+| `--max-topics` | 선택 | `30` | 최대 생성 토픽 수 (`>= --min-topics`) |
+| `--max-top-share` | 선택 | `0.35` | 적응형 클러스터링 최상위 토픽 쏠림 제한 (`0 < x <= 1`) |
+| `--display-limit` | 선택 | `30` | 토픽당 표시할 최대 대표 예시 개수 (`>= 0`) |
+| `--use-session-representatives` | 선택 | `false` | 세션별로 하나의 대표 예시만 추출하여 카운트 및 할당 폴백에 적용 |
+| `--ingestion-config` | 선택 | - | 커스텀 형태의 입력 처리를 위한 JSON 설정 파일 경로 |
+
+### 4.1 Ingestion 설정 형태 (`--ingestion-config`)
+
+설정 가능한 키:
+
+- `id_fields`: `TopicDocument.id`로 사용할 필드 후보 (우선순위 순)
+- `text_fields`: 텍스트로 직접 추출할 필드 후보 (우선순위 순)
+- `payload_fields`: JSON 페이로드 내에서 폴백(fallback)으로 사용할 필드 후보
+- `content_fields`: 연결하여 텍스트로 사용할 DB 열 이름 명시 (`field: value` 형식으로 연결됨)
+- `question_fields`: 질문 텍스트 후보
+- `response_fields`: 답변 텍스트 후보
+- `session_id_fields`: `session_id` 후보
+- `session_key_fields`: `session_id`를 조합하기 위해 사용할 기본 키 열 목록
+- `count_field`: 빈도수를 나타내는 필드 이름 (기본값: `count`)
+- `column_value_path`: 컬럼/값 쌍의 목록이 들어있는 데이터 내부 경로
+- `column_name_field`, `column_value_field`: 컬럼/값 항목 내부에서 키와 값을 나타내는 필드 이름
+- `max_text_chars`: 추출된 텍스트의 최대 길이 제한 (기본값: `4000`)
+
+설정 예시:
+
+```json
+{
+  "id_fields": ["account_id"],
+  "payload_fields": ["payload"],
+  "content_fields": ["query", "answer"],
+  "session_key_fields": ["account_id", "thread_id"],
+  "column_value_path": "columns",
+  "column_name_field": "column",
+  "column_value_field": "value"
+}
+```
+
+## 5) 문제 해결 (Troubleshooting)
+
+### 5.1 `cluster requires --base-url and --api-key` 오류
+
+명령어 실행 시 두 인자를 모두 제공해야 합니다:
+
+```bash
+--base-url https://... --api-key ...
+```
+
+### 5.2 `base_url must be a valid http(s) URL` 오류
+
+`http://` 또는 `https://`로 시작하는 유효한 엔드포인트 URL을 사용하세요.
+
+### 5.3 임베딩 요청 실패 (Embedding request failures)
+
+- 엔드포인트 네트워크 연결 상태 확인
+- API 키 유효성 검증
+- 최소 1줄의 입력 데이터로 단일 테스트 재시도
+
+### 5.4 Smoke 테스트에서 Wheel을 찾을 수 없는 경우
+
+스크립트에서 `Expected exactly one wheel` 오류 발생 시 아래 순서대로 빌드 환경을 초기화하세요:
+
+```bash
+rm -rf dist .venv-smoke-cli
+uv run python -m build
+uv run python scripts/smoke_installed_cli.py --dist-dir dist --venv-dir .venv-smoke-cli
+```

--- a/docs/user-manual.md
+++ b/docs/user-manual.md
@@ -97,7 +97,9 @@ used with `--ingestion-config`.
 ### 3.2 Input field behavior
 
 - `id`: preferred identifier; falls back to `document_id`, then row index
-- `text`: defaults to `""` when absent
+- `text`: resolved in order from `text_fields` → `content_fields` →
+  `payload_fields` → `question_fields`/`response_fields` QA pair →
+  serialized row JSON
 - `session_id`, `question`, `response`: optional
 - `count`: defaults to `1`
 
@@ -121,6 +123,7 @@ Command pattern:
 vector-topic-modeling cluster INPUT_JSONL --output OUTPUT_JSON
 ```
 
+<!-- markdownlint-disable MD013 -->
 | Option | Required | Default | Description |
 | --- | --- | --- | --- |
 | `input_path` | yes | - | Input JSONL file path |
@@ -129,7 +132,13 @@ vector-topic-modeling cluster INPUT_JSONL --output OUTPUT_JSON
 | `--api-key` | runtime-required | - | API key used for embedding requests |
 | `--model` | no | `text-embedding-3-large` | Embedding model |
 | `--similarity-threshold` | no | `0.85` | Clustering similarity threshold |
+| `--min-topics` | no | `2` | Minimum number of output topics (`>= 1`) |
+| `--max-topics` | no | `30` | Max output topics (`>= --min-topics`) |
+| `--max-top-share` | no | `0.35` | Dominant-topic cap for adaptive clustering and rescue (`0 < x <= 1`) |
+| `--display-limit` | no | `30` | Max representative examples per topic (`>= 0`) |
+| `--use-session-representatives` | no | `false` | Use one representative digest per session for counting and assignment fallback |
 | `--ingestion-config` | no | - | JSON config for generic row ingestion |
+<!-- markdownlint-enable MD013 -->
 
 Example with stricter threshold:
 
@@ -150,10 +159,14 @@ Config keys:
 - `text_fields`: ordered candidates for direct text extraction
 - `payload_fields`: ordered candidates for JSON payload fallback
 - `content_fields`: explicit DB column names to concatenate (`field: value`)
+- `question_fields`: ordered candidates for question text
+- `response_fields`: ordered candidates for response text
 - `session_id_fields`: ordered candidates for explicit `session_id`
 - `session_key_fields`: ordered primary-key columns used to compose `session_id`
+- `count_field`: source field mapped into `TopicDocument.count` (defaults to `count`)
 - `column_value_path`: row key containing list-style column/value pairs
 - `column_name_field`, `column_value_field`: keys used inside column/value entries
+- `max_text_chars`: normalization cap applied to resolved text (defaults to `4000`)
 
 Example:
 
@@ -223,7 +236,8 @@ uv run python scripts/smoke_installed_cli.py --dist-dir dist --venv-dir .venv-sm
    git push origin v0.1.1
    ```
 
-2. `.github/workflows/release.yml` verifies tests/build/smoke and creates a
+2. `.github/workflows/release.yml` verifies
+   tests/docstring coverage/build/smoke and creates a
    GitHub Release with built artifacts.
 3. `.github/workflows/publish.yml` then runs on `release.published` and uploads
    to PyPI using PyPI Trusted Publishing (OIDC).
@@ -285,14 +299,14 @@ sequenceDiagram
     GH->>R: Trigger on push.tags (v*)
     R->>R: Checkout tagged commit + validate SemVer tag
     R->>R: uv sync --extra dev
-    R->>R: pytest + build + smoke_installed_cli
+    R->>R: pytest + docstring_coverage + build + smoke_installed_cli
     R->>R: Generate SHA256SUMS for dist/*
     R->>REL: Create/update release and upload dist artifacts
 
     REL-->>GH: release.published event
     GH->>P: Trigger publish workflow
     P->>P: uv sync --extra dev
-    P->>P: Re-run pytest + build + smoke gate
+    P->>P: Re-run pytest + docstring_coverage + build + smoke gate
     P->>PY: pypa/gh-action-pypi-publish (dist/*)
     PY-->>M: New package version available
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,8 +26,9 @@ classifiers = [
 [dependency-groups]
 dev = [
   "build>=1.2.2",
+  "mypy>=1.19.1",
   "pytest>=8.3.0",
-  "pytest-cov>=7.1.0"
+  "pytest-cov>=7.1.0",
 ]
 
 [project.scripts]

--- a/scripts/review_checks/pr_check_gate_classifier.py
+++ b/scripts/review_checks/pr_check_gate_classifier.py
@@ -194,11 +194,15 @@ def main() -> int:
     args = parse_args()
     required_checks_arg = str(args.required_checks).strip()
     if required_checks_arg:
-        required_contexts = {
+        parsed_required_contexts = {
             context.strip()
             for context in required_checks_arg.split(",")
             if context.strip()
         }
+        if parsed_required_contexts:
+            required_contexts = parsed_required_contexts
+        else:
+            required_contexts = set(default_required_checks(str(args.base_branch)))
     else:
         required_contexts = set(default_required_checks(str(args.base_branch)))
 

--- a/scripts/smoke_installed_cli.py
+++ b/scripts/smoke_installed_cli.py
@@ -31,6 +31,8 @@ def build_smoke_commands(bin_dir: Path, os_name: str = os.name) -> list[list[str
         ],
         [cli_bin, "--help"],
         [cli_bin, "cluster", "--help"],
+        [python_bin, "-m", "vector_topic_modeling", "--help"],
+        [python_bin, "-m", "vector_topic_modeling", "cluster", "--help"],
     ]
 
 

--- a/src/vector_topic_modeling/__main__.py
+++ b/src/vector_topic_modeling/__main__.py
@@ -1,0 +1,8 @@
+"""Module entry point for the CLI."""
+
+import sys
+
+from vector_topic_modeling.cli import main
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_contributor_doc_policy_alignment.py
+++ b/tests/test_contributor_doc_policy_alignment.py
@@ -13,10 +13,20 @@ def _required_local_verification_fragments() -> list[str]:
     return [
         "uv run pytest -q",
         "uv run python scripts/docstring_coverage.py --min-percent 100",
+        "rm -rf dist .venv-smoke-cli",
         "uv run python -m build",
         "uv run python scripts/smoke_installed_cli.py --dist-dir dist --venv-dir .venv-smoke-cli",
-        "rm -rf dist .venv-smoke-cli",
     ]
+
+
+def _assert_fragments_in_order(
+    content: str, fragments: list[str], *, relpath: str
+) -> None:
+    previous = -1
+    for fragment in fragments:
+        index = content.find(fragment, previous + 1)
+        assert index >= 0, f"missing '{fragment}' in {relpath}"
+        previous = index
 
 
 def test_contributor_facing_docs_match_local_verification_contract() -> None:
@@ -31,9 +41,9 @@ def test_contributor_facing_docs_match_local_verification_contract() -> None:
         ".github/PULL_REQUEST_TEMPLATE.md": _read(".github/PULL_REQUEST_TEMPLATE.md"),
     }
 
+    fragments = _required_local_verification_fragments()
     for relpath, content in docs.items():
-        for fragment in _required_local_verification_fragments():
-            assert fragment in content, f"missing '{fragment}' in {relpath}"
+        _assert_fragments_in_order(content, fragments, relpath=relpath)
 
 
 def test_contributing_branching_guidance_matches_pr_branch_guard_policy() -> None:
@@ -43,3 +53,56 @@ def test_contributing_branching_guidance_matches_pr_branch_guard_policy() -> Non
     assert "Create a branch from `main`." not in content
     assert "feature branches merge into `dev`" in content
     assert "`dev` merges into `main`" in content
+
+
+def test_user_manual_documents_all_runtime_cli_tuning_options() -> None:
+    content = _read("docs/user-manual.md")
+
+    for option in [
+        "--min-topics",
+        "--max-topics",
+        "--max-top-share",
+        "--display-limit",
+        "--use-session-representatives",
+    ]:
+        assert f"`{option}`" in content
+
+
+def test_user_manual_documents_all_ingestion_config_keys() -> None:
+    content = _read("docs/user-manual.md")
+
+    for config_key in [
+        "id_fields",
+        "text_fields",
+        "payload_fields",
+        "content_fields",
+        "question_fields",
+        "response_fields",
+        "session_id_fields",
+        "session_key_fields",
+        "count_field",
+        "column_value_path",
+        "column_name_field",
+        "column_value_field",
+        "max_text_chars",
+    ]:
+        assert f"`{config_key}`" in content
+
+
+def test_user_manual_describes_text_resolution_fallback_order() -> None:
+    content = _read("docs/user-manual.md")
+
+    section_start = content.index("### 3.2 Input field behavior")
+    section_end = content.index("### 3.3 Output shape")
+    section = content[section_start:section_end]
+
+    ordered_markers = [
+        "`text_fields`",
+        "`content_fields`",
+        "`payload_fields`",
+        "`question_fields`",
+        "`response_fields`",
+        "serialized row JSON",
+    ]
+    positions = [section.index(marker) for marker in ordered_markers]
+    assert positions == sorted(positions)

--- a/tests/test_docs_ci_policy_alignment.py
+++ b/tests/test_docs_ci_policy_alignment.py
@@ -231,3 +231,18 @@ def test_dependency_review_scope_docs_match_main_target_trigger() -> None:
         assert "PRs targeting `main`" in content, relpath
         assert "every PR" not in content, relpath
         assert "each PR" not in content, relpath
+
+
+def test_release_docs_include_docstring_coverage_release_and_publish_gate() -> None:
+    release_workflow = _read(".github/workflows/release.yml")
+    publish_workflow = _read(".github/workflows/publish.yml")
+    assert "scripts/docstring_coverage.py --min-percent 100" in release_workflow
+    assert "scripts/docstring_coverage.py --min-percent 100" in publish_workflow
+
+    maintainers_doc = " ".join(_read("docs/maintainers/releasing.md").split())
+    assert "verifies tests/docstring coverage/build/smoke" in maintainers_doc
+
+    user_manual = " ".join(_read("docs/user-manual.md").split())
+    assert "verifies tests/docstring coverage/build/smoke" in user_manual
+    assert "pytest + docstring_coverage + build + smoke_installed_cli" in user_manual
+    assert "Re-run pytest + docstring_coverage + build + smoke gate" in user_manual

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,26 @@
+"""Test module entrypoint."""
+
+import runpy
+import sys
+from unittest.mock import patch
+
+
+def test_module_execution():
+    """Ensure `python -m vector_topic_modeling` executes the CLI."""
+    with (
+        patch.object(sys, "argv", ["vector_topic_modeling", "cluster", "--help"]),
+        patch("vector_topic_modeling.cli.main", return_value=0) as mock_main,
+    ):
+        try:
+            runpy.run_module("vector_topic_modeling", run_name="__main__")
+        except SystemExit as e:
+            assert e.code == 0
+        mock_main.assert_called_once()
+
+
+def test_module_import():
+    """Ensure importing `__main__` does not execute main()."""
+    with patch("vector_topic_modeling.cli.main") as mock_main:
+        import vector_topic_modeling.__main__  # noqa: F401
+
+        mock_main.assert_not_called()

--- a/tests/test_pr_check_gate_classifier.py
+++ b/tests/test_pr_check_gate_classifier.py
@@ -302,6 +302,25 @@ def test_main_returns_1_when_required_context_fails(monkeypatch, capsys) -> None
     assert "gate=FAIL" in capsys.readouterr().out
 
 
+def test_main_falls_back_to_base_defaults_when_required_checks_csv_is_empty(
+    monkeypatch, capsys
+) -> None:
+    monkeypatch.setattr(
+        MODULE,
+        "parse_args",
+        lambda: SimpleNamespace(required_checks=", ,", base_branch="main"),
+    )
+    monkeypatch.setattr(MODULE, "_read_stdin", lambda: json.dumps([]))
+
+    exit_code = MODULE.main()
+    output = capsys.readouterr().out
+
+    assert exit_code == 1
+    assert "gate=FAIL" in output
+    assert "required_pending:[" in output
+    assert "workflow-lint" in output
+
+
 def test_main_returns_2_when_input_is_not_json(monkeypatch, capsys) -> None:
     monkeypatch.setattr(
         MODULE,

--- a/tests/test_smoke_installed_cli.py
+++ b/tests/test_smoke_installed_cli.py
@@ -73,6 +73,19 @@ def test_build_smoke_commands_cover_import_and_cli_entrypoint(tmp_path: Path) ->
         "cluster",
         "--help",
     ]
+    assert commands[4] == [
+        str(bin_dir / "python"),
+        "-m",
+        "vector_topic_modeling",
+        "--help",
+    ]
+    assert commands[5] == [
+        str(bin_dir / "python"),
+        "-m",
+        "vector_topic_modeling",
+        "cluster",
+        "--help",
+    ]
 
 
 def test_windows_smoke_commands_use_python_exe(tmp_path: Path) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -139,12 +139,142 @@ wheels = [
 ]
 
 [[package]]
+name = "librt"
+version = "0.8.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/56/9c/b4b0c54d84da4a94b37bd44151e46d5e583c9534c7e02250b961b1b6d8a8/librt-0.8.1.tar.gz", hash = "sha256:be46a14693955b3bd96014ccbdb8339ee8c9346fbe11c1b78901b55125f14c73", size = 177471, upload-time = "2026-02-17T16:13:06.101Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/01/0e748af5e4fee180cf7cd12bd12b0513ad23b045dccb2a83191bde82d168/librt-0.8.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:681dc2451d6d846794a828c16c22dc452d924e9f700a485b7ecb887a30aad1fd", size = 65315, upload-time = "2026-02-17T16:11:25.152Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/4d/7184806efda571887c798d573ca4134c80ac8642dcdd32f12c31b939c595/librt-0.8.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a3b4350b13cc0e6f5bec8fa7caf29a8fb8cdc051a3bae45cfbfd7ce64f009965", size = 68021, upload-time = "2026-02-17T16:11:26.129Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/88/c3c52d2a5d5101f28d3dc89298444626e7874aa904eed498464c2af17627/librt-0.8.1-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:ac1e7817fd0ed3d14fd7c5df91daed84c48e4c2a11ee99c0547f9f62fdae13da", size = 194500, upload-time = "2026-02-17T16:11:27.177Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/5d/6fb0a25b6a8906e85b2c3b87bee1d6ed31510be7605b06772f9374ca5cb3/librt-0.8.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:747328be0c5b7075cde86a0e09d7a9196029800ba75a1689332348e998fb85c0", size = 205622, upload-time = "2026-02-17T16:11:28.242Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/a6/8006ae81227105476a45691f5831499e4d936b1c049b0c1feb17c11b02d1/librt-0.8.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f0af2bd2bc204fa27f3d6711d0f360e6b8c684a035206257a81673ab924aa11e", size = 218304, upload-time = "2026-02-17T16:11:29.344Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/19/60e07886ad16670aae57ef44dada41912c90906a6fe9f2b9abac21374748/librt-0.8.1-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d480de377f5b687b6b1bc0c0407426da556e2a757633cc7e4d2e1a057aa688f3", size = 211493, upload-time = "2026-02-17T16:11:30.445Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/cf/f666c89d0e861d05600438213feeb818c7514d3315bae3648b1fc145d2b6/librt-0.8.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d0ee06b5b5291f609ddb37b9750985b27bc567791bc87c76a569b3feed8481ac", size = 219129, upload-time = "2026-02-17T16:11:32.021Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/ef/f1bea01e40b4a879364c031476c82a0dc69ce068daad67ab96302fed2d45/librt-0.8.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:9e2c6f77b9ad48ce5603b83b7da9ee3e36b3ab425353f695cba13200c5d96596", size = 213113, upload-time = "2026-02-17T16:11:33.192Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/80/cdab544370cc6bc1b72ea369525f547a59e6938ef6863a11ab3cd24759af/librt-0.8.1-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:439352ba9373f11cb8e1933da194dcc6206daf779ff8df0ed69c5e39113e6a99", size = 212269, upload-time = "2026-02-17T16:11:34.373Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/9c/48d6ed8dac595654f15eceab2035131c136d1ae9a1e3548e777bb6dbb95d/librt-0.8.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:82210adabbc331dbb65d7868b105185464ef13f56f7f76688565ad79f648b0fe", size = 234673, upload-time = "2026-02-17T16:11:36.063Z" },
+    { url = "https://files.pythonhosted.org/packages/16/01/35b68b1db517f27a01be4467593292eb5315def8900afad29fabf56304ba/librt-0.8.1-cp311-cp311-win32.whl", hash = "sha256:52c224e14614b750c0a6d97368e16804a98c684657c7518752c356834fff83bb", size = 54597, upload-time = "2026-02-17T16:11:37.544Z" },
+    { url = "https://files.pythonhosted.org/packages/71/02/796fe8f02822235966693f257bf2c79f40e11337337a657a8cfebba5febc/librt-0.8.1-cp311-cp311-win_amd64.whl", hash = "sha256:c00e5c884f528c9932d278d5c9cbbea38a6b81eb62c02e06ae53751a83a4d52b", size = 61733, upload-time = "2026-02-17T16:11:38.691Z" },
+    { url = "https://files.pythonhosted.org/packages/28/ad/232e13d61f879a42a4e7117d65e4984bb28371a34bb6fb9ca54ec2c8f54e/librt-0.8.1-cp311-cp311-win_arm64.whl", hash = "sha256:f7cdf7f26c2286ffb02e46d7bac56c94655540b26347673bea15fa52a6af17e9", size = 52273, upload-time = "2026-02-17T16:11:40.308Z" },
+    { url = "https://files.pythonhosted.org/packages/95/21/d39b0a87ac52fc98f621fb6f8060efb017a767ebbbac2f99fbcbc9ddc0d7/librt-0.8.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:a28f2612ab566b17f3698b0da021ff9960610301607c9a5e8eaca62f5e1c350a", size = 66516, upload-time = "2026-02-17T16:11:41.604Z" },
+    { url = "https://files.pythonhosted.org/packages/69/f1/46375e71441c43e8ae335905e069f1c54febee63a146278bcee8782c84fd/librt-0.8.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:60a78b694c9aee2a0f1aaeaa7d101cf713e92e8423a941d2897f4fa37908dab9", size = 68634, upload-time = "2026-02-17T16:11:43.268Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/33/c510de7f93bf1fa19e13423a606d8189a02624a800710f6e6a0a0f0784b3/librt-0.8.1-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:758509ea3f1eba2a57558e7e98f4659d0ea7670bff49673b0dde18a3c7e6c0eb", size = 198941, upload-time = "2026-02-17T16:11:44.28Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/36/e725903416409a533d92398e88ce665476f275081d0d7d42f9c4951999e5/librt-0.8.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:039b9f2c506bd0ab0f8725aa5ba339c6f0cd19d3b514b50d134789809c24285d", size = 209991, upload-time = "2026-02-17T16:11:45.462Z" },
+    { url = "https://files.pythonhosted.org/packages/30/7a/8d908a152e1875c9f8eac96c97a480df425e657cdb47854b9efaa4998889/librt-0.8.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5bb54f1205a3a6ab41a6fd71dfcdcbd278670d3a90ca502a30d9da583105b6f7", size = 224476, upload-time = "2026-02-17T16:11:46.542Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/b8/a22c34f2c485b8903a06f3fe3315341fe6876ef3599792344669db98fcff/librt-0.8.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:05bd41cdee35b0c59c259f870f6da532a2c5ca57db95b5f23689fcb5c9e42440", size = 217518, upload-time = "2026-02-17T16:11:47.746Z" },
+    { url = "https://files.pythonhosted.org/packages/79/6f/5c6fea00357e4f82ba44f81dbfb027921f1ab10e320d4a64e1c408d035d9/librt-0.8.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:adfab487facf03f0d0857b8710cf82d0704a309d8ffc33b03d9302b4c64e91a9", size = 225116, upload-time = "2026-02-17T16:11:49.298Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/a0/95ced4e7b1267fe1e2720a111685bcddf0e781f7e9e0ce59d751c44dcfe5/librt-0.8.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:153188fe98a72f206042be10a2c6026139852805215ed9539186312d50a8e972", size = 217751, upload-time = "2026-02-17T16:11:50.49Z" },
+    { url = "https://files.pythonhosted.org/packages/93/c2/0517281cb4d4101c27ab59472924e67f55e375bc46bedae94ac6dc6e1902/librt-0.8.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:dd3c41254ee98604b08bd5b3af5bf0a89740d4ee0711de95b65166bf44091921", size = 218378, upload-time = "2026-02-17T16:11:51.783Z" },
+    { url = "https://files.pythonhosted.org/packages/43/e8/37b3ac108e8976888e559a7b227d0ceac03c384cfd3e7a1c2ee248dbae79/librt-0.8.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e0d138c7ae532908cbb342162b2611dbd4d90c941cd25ab82084aaf71d2c0bd0", size = 241199, upload-time = "2026-02-17T16:11:53.561Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/5b/35812d041c53967fedf551a39399271bbe4257e681236a2cf1a69c8e7fa1/librt-0.8.1-cp312-cp312-win32.whl", hash = "sha256:43353b943613c5d9c49a25aaffdba46f888ec354e71e3529a00cca3f04d66a7a", size = 54917, upload-time = "2026-02-17T16:11:54.758Z" },
+    { url = "https://files.pythonhosted.org/packages/de/d1/fa5d5331b862b9775aaf2a100f5ef86854e5d4407f71bddf102f4421e034/librt-0.8.1-cp312-cp312-win_amd64.whl", hash = "sha256:ff8baf1f8d3f4b6b7257fcb75a501f2a5499d0dda57645baa09d4d0d34b19444", size = 62017, upload-time = "2026-02-17T16:11:55.748Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/7c/c614252f9acda59b01a66e2ddfd243ed1c7e1deab0293332dfbccf862808/librt-0.8.1-cp312-cp312-win_arm64.whl", hash = "sha256:0f2ae3725904f7377e11cc37722d5d401e8b3d5851fb9273d7f4fe04f6b3d37d", size = 52441, upload-time = "2026-02-17T16:11:56.801Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/3c/f614c8e4eaac7cbf2bbdf9528790b21d89e277ee20d57dc6e559c626105f/librt-0.8.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:7e6bad1cd94f6764e1e21950542f818a09316645337fd5ab9a7acc45d99a8f35", size = 66529, upload-time = "2026-02-17T16:11:57.809Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/96/5836544a45100ae411eda07d29e3d99448e5258b6e9c8059deb92945f5c2/librt-0.8.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:cf450f498c30af55551ba4f66b9123b7185362ec8b625a773b3d39aa1a717583", size = 68669, upload-time = "2026-02-17T16:11:58.843Z" },
+    { url = "https://files.pythonhosted.org/packages/06/53/f0b992b57af6d5531bf4677d75c44f095f2366a1741fb695ee462ae04b05/librt-0.8.1-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:eca45e982fa074090057132e30585a7e8674e9e885d402eae85633e9f449ce6c", size = 199279, upload-time = "2026-02-17T16:11:59.862Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/ad/4848cc16e268d14280d8168aee4f31cea92bbd2b79ce33d3e166f2b4e4fc/librt-0.8.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0c3811485fccfda840861905b8c70bba5ec094e02825598bb9d4ca3936857a04", size = 210288, upload-time = "2026-02-17T16:12:00.954Z" },
+    { url = "https://files.pythonhosted.org/packages/52/05/27fdc2e95de26273d83b96742d8d3b7345f2ea2bdbd2405cc504644f2096/librt-0.8.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5e4af413908f77294605e28cfd98063f54b2c790561383971d2f52d113d9c363", size = 224809, upload-time = "2026-02-17T16:12:02.108Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/d0/78200a45ba3240cb042bc597d6f2accba9193a2c57d0356268cbbe2d0925/librt-0.8.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:5212a5bd7fae98dae95710032902edcd2ec4dc994e883294f75c857b83f9aba0", size = 218075, upload-time = "2026-02-17T16:12:03.631Z" },
+    { url = "https://files.pythonhosted.org/packages/af/72/a210839fa74c90474897124c064ffca07f8d4b347b6574d309686aae7ca6/librt-0.8.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:e692aa2d1d604e6ca12d35e51fdc36f4cda6345e28e36374579f7ef3611b3012", size = 225486, upload-time = "2026-02-17T16:12:04.725Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/c1/a03cc63722339ddbf087485f253493e2b013039f5b707e8e6016141130fa/librt-0.8.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:4be2a5c926b9770c9e08e717f05737a269b9d0ebc5d2f0060f0fe3fe9ce47acb", size = 218219, upload-time = "2026-02-17T16:12:05.828Z" },
+    { url = "https://files.pythonhosted.org/packages/58/f5/fff6108af0acf941c6f274a946aea0e484bd10cd2dc37610287ce49388c5/librt-0.8.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:fd1a720332ea335ceb544cf0a03f81df92abd4bb887679fd1e460976b0e6214b", size = 218750, upload-time = "2026-02-17T16:12:07.09Z" },
+    { url = "https://files.pythonhosted.org/packages/71/67/5a387bfef30ec1e4b4f30562c8586566faf87e47d696768c19feb49e3646/librt-0.8.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:93c2af9e01e0ef80d95ae3c720be101227edae5f2fe7e3dc63d8857fadfc5a1d", size = 241624, upload-time = "2026-02-17T16:12:08.43Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/be/24f8502db11d405232ac1162eb98069ca49c3306c1d75c6ccc61d9af8789/librt-0.8.1-cp313-cp313-win32.whl", hash = "sha256:086a32dbb71336627e78cc1d6ee305a68d038ef7d4c39aaff41ae8c9aa46e91a", size = 54969, upload-time = "2026-02-17T16:12:09.633Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/73/c9fdf6cb2a529c1a092ce769a12d88c8cca991194dfe641b6af12fa964d2/librt-0.8.1-cp313-cp313-win_amd64.whl", hash = "sha256:e11769a1dbda4da7b00a76cfffa67aa47cfa66921d2724539eee4b9ede780b79", size = 62000, upload-time = "2026-02-17T16:12:10.632Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/97/68f80ca3ac4924f250cdfa6e20142a803e5e50fca96ef5148c52ee8c10ea/librt-0.8.1-cp313-cp313-win_arm64.whl", hash = "sha256:924817ab3141aca17893386ee13261f1d100d1ef410d70afe4389f2359fea4f0", size = 52495, upload-time = "2026-02-17T16:12:11.633Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/6a/907ef6800f7bca71b525a05f1839b21f708c09043b1c6aa77b6b827b3996/librt-0.8.1-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:6cfa7fe54fd4d1f47130017351a959fe5804bda7a0bc7e07a2cdbc3fdd28d34f", size = 66081, upload-time = "2026-02-17T16:12:12.766Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/18/25e991cd5640c9fb0f8d91b18797b29066b792f17bf8493da183bf5caabe/librt-0.8.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:228c2409c079f8c11fb2e5d7b277077f694cb93443eb760e00b3b83cb8b3176c", size = 68309, upload-time = "2026-02-17T16:12:13.756Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/36/46820d03f058cfb5a9de5940640ba03165ed8aded69e0733c417bb04df34/librt-0.8.1-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:7aae78ab5e3206181780e56912d1b9bb9f90a7249ce12f0e8bf531d0462dd0fc", size = 196804, upload-time = "2026-02-17T16:12:14.818Z" },
+    { url = "https://files.pythonhosted.org/packages/59/18/5dd0d3b87b8ff9c061849fbdb347758d1f724b9a82241aa908e0ec54ccd0/librt-0.8.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:172d57ec04346b047ca6af181e1ea4858086c80bdf455f61994c4aa6fc3f866c", size = 206907, upload-time = "2026-02-17T16:12:16.513Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/96/ef04902aad1424fd7299b62d1890e803e6ab4018c3044dca5922319c4b97/librt-0.8.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6b1977c4ea97ce5eb7755a78fae68d87e4102e4aaf54985e8b56806849cc06a3", size = 221217, upload-time = "2026-02-17T16:12:17.906Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/ff/7e01f2dda84a8f5d280637a2e5827210a8acca9a567a54507ef1c75b342d/librt-0.8.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:10c42e1f6fd06733ef65ae7bebce2872bcafd8d6e6b0a08fe0a05a23b044fb14", size = 214622, upload-time = "2026-02-17T16:12:19.108Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/8c/5b093d08a13946034fed57619742f790faf77058558b14ca36a6e331161e/librt-0.8.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:4c8dfa264b9193c4ee19113c985c95f876fae5e51f731494fc4e0cf594990ba7", size = 221987, upload-time = "2026-02-17T16:12:20.331Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/cc/86b0b3b151d40920ad45a94ce0171dec1aebba8a9d72bb3fa00c73ab25dd/librt-0.8.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:01170b6729a438f0dedc4a26ed342e3dc4f02d1000b4b19f980e1877f0c297e6", size = 215132, upload-time = "2026-02-17T16:12:21.54Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/be/8588164a46edf1e69858d952654e216a9a91174688eeefb9efbb38a9c799/librt-0.8.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:7b02679a0d783bdae30d443025b94465d8c3dc512f32f5b5031f93f57ac32071", size = 215195, upload-time = "2026-02-17T16:12:23.073Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/f2/0b9279bea735c734d69344ecfe056c1ba211694a72df10f568745c899c76/librt-0.8.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:190b109bb69592a3401fe1ffdea41a2e73370ace2ffdc4a0e8e2b39cdea81b78", size = 237946, upload-time = "2026-02-17T16:12:24.275Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/cc/5f2a34fbc8aeb35314a3641f9956fa9051a947424652fad9882be7a97949/librt-0.8.1-cp314-cp314-win32.whl", hash = "sha256:e70a57ecf89a0f64c24e37f38d3fe217a58169d2fe6ed6d70554964042474023", size = 50689, upload-time = "2026-02-17T16:12:25.766Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/76/cd4d010ab2147339ca2b93e959c3686e964edc6de66ddacc935c325883d7/librt-0.8.1-cp314-cp314-win_amd64.whl", hash = "sha256:7e2f3edca35664499fbb36e4770650c4bd4a08abc1f4458eab9df4ec56389730", size = 57875, upload-time = "2026-02-17T16:12:27.465Z" },
+    { url = "https://files.pythonhosted.org/packages/84/0f/2143cb3c3ca48bd3379dcd11817163ca50781927c4537345d608b5045998/librt-0.8.1-cp314-cp314-win_arm64.whl", hash = "sha256:0d2f82168e55ddefd27c01c654ce52379c0750ddc31ee86b4b266bcf4d65f2a3", size = 48058, upload-time = "2026-02-17T16:12:28.556Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/0e/9b23a87e37baf00311c3efe6b48d6b6c168c29902dfc3f04c338372fd7db/librt-0.8.1-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:2c74a2da57a094bd48d03fa5d196da83d2815678385d2978657499063709abe1", size = 68313, upload-time = "2026-02-17T16:12:29.659Z" },
+    { url = "https://files.pythonhosted.org/packages/db/9a/859c41e5a4f1c84200a7d2b92f586aa27133c8243b6cac9926f6e54d01b9/librt-0.8.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a355d99c4c0d8e5b770313b8b247411ed40949ca44e33e46a4789b9293a907ee", size = 70994, upload-time = "2026-02-17T16:12:31.516Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/28/10605366ee599ed34223ac2bf66404c6fb59399f47108215d16d5ad751a8/librt-0.8.1-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:2eb345e8b33fb748227409c9f1233d4df354d6e54091f0e8fc53acdb2ffedeb7", size = 220770, upload-time = "2026-02-17T16:12:33.294Z" },
+    { url = "https://files.pythonhosted.org/packages/af/8d/16ed8fd452dafae9c48d17a6bc1ee3e818fd40ef718d149a8eff2c9f4ea2/librt-0.8.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9be2f15e53ce4e83cc08adc29b26fb5978db62ef2a366fbdf716c8a6c8901040", size = 235409, upload-time = "2026-02-17T16:12:35.443Z" },
+    { url = "https://files.pythonhosted.org/packages/89/1b/7bdf3e49349c134b25db816e4a3db6b94a47ac69d7d46b1e682c2c4949be/librt-0.8.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:785ae29c1f5c6e7c2cde2c7c0e148147f4503da3abc5d44d482068da5322fd9e", size = 246473, upload-time = "2026-02-17T16:12:36.656Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/8a/91fab8e4fd2a24930a17188c7af5380eb27b203d72101c9cc000dbdfd95a/librt-0.8.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1d3a7da44baf692f0c6aeb5b2a09c5e6fc7a703bca9ffa337ddd2e2da53f7732", size = 238866, upload-time = "2026-02-17T16:12:37.849Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/e0/c45a098843fc7c07e18a7f8a24ca8496aecbf7bdcd54980c6ca1aaa79a8e/librt-0.8.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:5fc48998000cbc39ec0d5311312dda93ecf92b39aaf184c5e817d5d440b29624", size = 250248, upload-time = "2026-02-17T16:12:39.445Z" },
+    { url = "https://files.pythonhosted.org/packages/82/30/07627de23036640c952cce0c1fe78972e77d7d2f8fd54fa5ef4554ff4a56/librt-0.8.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:e96baa6820280077a78244b2e06e416480ed859bbd8e5d641cf5742919d8beb4", size = 240629, upload-time = "2026-02-17T16:12:40.889Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/c1/55bfe1ee3542eba055616f9098eaf6eddb966efb0ca0f44eaa4aba327307/librt-0.8.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:31362dbfe297b23590530007062c32c6f6176f6099646bb2c95ab1b00a57c382", size = 239615, upload-time = "2026-02-17T16:12:42.446Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/39/191d3d28abc26c9099b19852e6c99f7f6d400b82fa5a4e80291bd3803e19/librt-0.8.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:cc3656283d11540ab0ea01978378e73e10002145117055e03722417aeab30994", size = 263001, upload-time = "2026-02-17T16:12:43.627Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/eb/7697f60fbe7042ab4e88f4ee6af496b7f222fffb0a4e3593ef1f29f81652/librt-0.8.1-cp314-cp314t-win32.whl", hash = "sha256:738f08021b3142c2918c03692608baed43bc51144c29e35807682f8070ee2a3a", size = 51328, upload-time = "2026-02-17T16:12:45.148Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/72/34bf2eb7a15414a23e5e70ecb9440c1d3179f393d9349338a91e2781c0fb/librt-0.8.1-cp314-cp314t-win_amd64.whl", hash = "sha256:89815a22daf9c51884fb5dbe4f1ef65ee6a146e0b6a8df05f753e2e4a9359bf4", size = 58722, upload-time = "2026-02-17T16:12:46.85Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/c8/d148e041732d631fc76036f8b30fae4e77b027a1e95b7a84bb522481a940/librt-0.8.1-cp314-cp314t-win_arm64.whl", hash = "sha256:bf512a71a23504ed08103a13c941f763db13fb11177beb3d9244c98c29fb4a61", size = 48755, upload-time = "2026-02-17T16:12:47.943Z" },
+]
+
+[[package]]
+name = "mypy"
+version = "1.19.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "librt", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "mypy-extensions" },
+    { name = "pathspec" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f5/db/4efed9504bc01309ab9c2da7e352cc223569f05478012b5d9ece38fd44d2/mypy-1.19.1.tar.gz", hash = "sha256:19d88bb05303fe63f71dd2c6270daca27cb9401c4ca8255fe50d1d920e0eb9ba", size = 3582404, upload-time = "2025-12-15T05:03:48.42Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/47/6b3ebabd5474d9cdc170d1342fbf9dddc1b0ec13ec90bf9004ee6f391c31/mypy-1.19.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:d8dfc6ab58ca7dda47d9237349157500468e404b17213d44fc1cb77bce532288", size = 13028539, upload-time = "2025-12-15T05:03:44.129Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/a6/ac7c7a88a3c9c54334f53a941b765e6ec6c4ebd65d3fe8cdcfbe0d0fd7db/mypy-1.19.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e3f276d8493c3c97930e354b2595a44a21348b320d859fb4a2b9f66da9ed27ab", size = 12083163, upload-time = "2025-12-15T05:03:37.679Z" },
+    { url = "https://files.pythonhosted.org/packages/67/af/3afa9cf880aa4a2c803798ac24f1d11ef72a0c8079689fac5cfd815e2830/mypy-1.19.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2abb24cf3f17864770d18d673c85235ba52456b36a06b6afc1e07c1fdcd3d0e6", size = 12687629, upload-time = "2025-12-15T05:02:31.526Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/46/20f8a7114a56484ab268b0ab372461cb3a8f7deed31ea96b83a4e4cfcfca/mypy-1.19.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a009ffa5a621762d0c926a078c2d639104becab69e79538a494bcccb62cc0331", size = 13436933, upload-time = "2025-12-15T05:03:15.606Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/f8/33b291ea85050a21f15da910002460f1f445f8007adb29230f0adea279cb/mypy-1.19.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f7cee03c9a2e2ee26ec07479f38ea9c884e301d42c6d43a19d20fb014e3ba925", size = 13661754, upload-time = "2025-12-15T05:02:26.731Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/a3/47cbd4e85bec4335a9cd80cf67dbc02be21b5d4c9c23ad6b95d6c5196bac/mypy-1.19.1-cp311-cp311-win_amd64.whl", hash = "sha256:4b84a7a18f41e167f7995200a1d07a4a6810e89d29859df936f1c3923d263042", size = 10055772, upload-time = "2025-12-15T05:03:26.179Z" },
+    { url = "https://files.pythonhosted.org/packages/06/8a/19bfae96f6615aa8a0604915512e0289b1fad33d5909bf7244f02935d33a/mypy-1.19.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:a8174a03289288c1f6c46d55cef02379b478bfbc8e358e02047487cad44c6ca1", size = 13206053, upload-time = "2025-12-15T05:03:46.622Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/34/3e63879ab041602154ba2a9f99817bb0c85c4df19a23a1443c8986e4d565/mypy-1.19.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ffcebe56eb09ff0c0885e750036a095e23793ba6c2e894e7e63f6d89ad51f22e", size = 12219134, upload-time = "2025-12-15T05:03:24.367Z" },
+    { url = "https://files.pythonhosted.org/packages/89/cc/2db6f0e95366b630364e09845672dbee0cbf0bbe753a204b29a944967cd9/mypy-1.19.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b64d987153888790bcdb03a6473d321820597ab8dd9243b27a92153c4fa50fd2", size = 12731616, upload-time = "2025-12-15T05:02:44.725Z" },
+    { url = "https://files.pythonhosted.org/packages/00/be/dd56c1fd4807bc1eba1cf18b2a850d0de7bacb55e158755eb79f77c41f8e/mypy-1.19.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c35d298c2c4bba75feb2195655dfea8124d855dfd7343bf8b8c055421eaf0cf8", size = 13620847, upload-time = "2025-12-15T05:03:39.633Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/42/332951aae42b79329f743bf1da088cd75d8d4d9acc18fbcbd84f26c1af4e/mypy-1.19.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:34c81968774648ab5ac09c29a375fdede03ba253f8f8287847bd480782f73a6a", size = 13834976, upload-time = "2025-12-15T05:03:08.786Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/63/e7493e5f90e1e085c562bb06e2eb32cae27c5057b9653348d38b47daaecc/mypy-1.19.1-cp312-cp312-win_amd64.whl", hash = "sha256:b10e7c2cd7870ba4ad9b2d8a6102eb5ffc1f16ca35e3de6bfa390c1113029d13", size = 10118104, upload-time = "2025-12-15T05:03:10.834Z" },
+    { url = "https://files.pythonhosted.org/packages/de/9f/a6abae693f7a0c697dbb435aac52e958dc8da44e92e08ba88d2e42326176/mypy-1.19.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e3157c7594ff2ef1634ee058aafc56a82db665c9438fd41b390f3bde1ab12250", size = 13201927, upload-time = "2025-12-15T05:02:29.138Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a4/45c35ccf6e1c65afc23a069f50e2c66f46bd3798cbe0d680c12d12935caa/mypy-1.19.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:bdb12f69bcc02700c2b47e070238f42cb87f18c0bc1fc4cdb4fb2bc5fd7a3b8b", size = 12206730, upload-time = "2025-12-15T05:03:01.325Z" },
+    { url = "https://files.pythonhosted.org/packages/05/bb/cdcf89678e26b187650512620eec8368fded4cfd99cfcb431e4cdfd19dec/mypy-1.19.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f859fb09d9583a985be9a493d5cfc5515b56b08f7447759a0c5deaf68d80506e", size = 12724581, upload-time = "2025-12-15T05:03:20.087Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/32/dd260d52babf67bad8e6770f8e1102021877ce0edea106e72df5626bb0ec/mypy-1.19.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c9a6538e0415310aad77cb94004ca6482330fece18036b5f360b62c45814c4ef", size = 13616252, upload-time = "2025-12-15T05:02:49.036Z" },
+    { url = "https://files.pythonhosted.org/packages/71/d0/5e60a9d2e3bd48432ae2b454b7ef2b62a960ab51292b1eda2a95edd78198/mypy-1.19.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:da4869fc5e7f62a88f3fe0b5c919d1d9f7ea3cef92d3689de2823fd27e40aa75", size = 13840848, upload-time = "2025-12-15T05:02:55.95Z" },
+    { url = "https://files.pythonhosted.org/packages/98/76/d32051fa65ecf6cc8c6610956473abdc9b4c43301107476ac03559507843/mypy-1.19.1-cp313-cp313-win_amd64.whl", hash = "sha256:016f2246209095e8eda7538944daa1d60e1e8134d98983b9fc1e92c1fc0cb8dd", size = 10135510, upload-time = "2025-12-15T05:02:58.438Z" },
+    { url = "https://files.pythonhosted.org/packages/de/eb/b83e75f4c820c4247a58580ef86fcd35165028f191e7e1ba57128c52782d/mypy-1.19.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:06e6170bd5836770e8104c8fdd58e5e725cfeb309f0a6c681a811f557e97eac1", size = 13199744, upload-time = "2025-12-15T05:03:30.823Z" },
+    { url = "https://files.pythonhosted.org/packages/94/28/52785ab7bfa165f87fcbb61547a93f98bb20e7f82f90f165a1f69bce7b3d/mypy-1.19.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:804bd67b8054a85447c8954215a906d6eff9cabeabe493fb6334b24f4bfff718", size = 12215815, upload-time = "2025-12-15T05:02:42.323Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/c6/bdd60774a0dbfb05122e3e925f2e9e846c009e479dcec4821dad881f5b52/mypy-1.19.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:21761006a7f497cb0d4de3d8ef4ca70532256688b0523eee02baf9eec895e27b", size = 12740047, upload-time = "2025-12-15T05:03:33.168Z" },
+    { url = "https://files.pythonhosted.org/packages/32/2a/66ba933fe6c76bd40d1fe916a83f04fed253152f451a877520b3c4a5e41e/mypy-1.19.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:28902ee51f12e0f19e1e16fbe2f8f06b6637f482c459dd393efddd0ec7f82045", size = 13601998, upload-time = "2025-12-15T05:03:13.056Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/da/5055c63e377c5c2418760411fd6a63ee2b96cf95397259038756c042574f/mypy-1.19.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:481daf36a4c443332e2ae9c137dfee878fcea781a2e3f895d54bd3002a900957", size = 13807476, upload-time = "2025-12-15T05:03:17.977Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/09/4ebd873390a063176f06b0dbf1f7783dd87bd120eae7727fa4ae4179b685/mypy-1.19.1-cp314-cp314-win_amd64.whl", hash = "sha256:8bb5c6f6d043655e055be9b542aa5f3bdd30e4f3589163e85f93f3640060509f", size = 10281872, upload-time = "2025-12-15T05:03:05.549Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/f4/4ce9a05ce5ded1de3ec1c1d96cf9f9504a04e54ce0ed55cfa38619a32b8d/mypy-1.19.1-py3-none-any.whl", hash = "sha256:f1235f5ea01b7db5468d53ece6aaddf1ad0b88d9e7462b86ef96fe04995d7247", size = 2471239, upload-time = "2025-12-15T05:03:07.248Z" },
+]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "1.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fa/36/e27608899f9b8d4dff0617b2d9ab17ca5608956ca44461ac14ac48b44015/pathspec-1.0.4.tar.gz", hash = "sha256:0210e2ae8a21a9137c0d470578cb0e595af87edaa6ebf12ff176f14a02e0e645", size = 131200, upload-time = "2026-01-27T03:59:46.938Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/3c/2c197d226f9ea224a9ab8d197933f9da0ae0aac5b6e0f884e2b8d9c8e9f7/pathspec-1.0.4-py3-none-any.whl", hash = "sha256:fb6ae2fd4e7c921a165808a552060e722767cfa526f99ca5156ed2ce45a5c723", size = 55206, upload-time = "2026-01-27T03:59:45.137Z" },
 ]
 
 [[package]]
@@ -259,6 +389,15 @@ wheels = [
 ]
 
 [[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
 name = "vector-topic-modeling"
 version = "0.1.0"
 source = { editable = "." }
@@ -266,6 +405,7 @@ source = { editable = "." }
 [package.dev-dependencies]
 dev = [
     { name = "build" },
+    { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-cov" },
 ]
@@ -275,6 +415,7 @@ dev = [
 [package.metadata.requires-dev]
 dev = [
     { name = "build", specifier = ">=1.2.2" },
+    { name = "mypy", specifier = ">=1.19.1" },
     { name = "pytest", specifier = ">=8.3.0" },
     { name = "pytest-cov", specifier = ">=7.1.0" },
 ]


### PR DESCRIPTION
## Summary
* Added `__main__.py` to provide module-level execution (`python -m vector_topic_modeling`)
* Added `tests/test_main.py` to verify execution and import behavior
* Resolves missing functionality for standard python toolchain usage