### PR TITLE
fix: reuse precomputed silhouette and harden distributed cleanup

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -39,10 +39,13 @@ Last updated: 2026-03-29
    from dominating.
 7. Optional extended metrics (Silhouette, Calinski-Harabasz, Davies-Bouldin)
    can be calculated via `evaluation.py`, and can be parallelized using Valkey
-   (`distributed.py`) to reduce heavy pairwise distance computation time. Both
-   local and distributed silhouette paths short-circuit to neutral scores when
-   fewer than two populated clusters remain after vector filtering, and the
-   distributed path falls back to local metrics if worker output is partial.
+   (`distributed.py`) to reduce heavy pairwise distance computation time. The
+   pipeline reuses precomputed silhouette scores when both silhouette and
+   extended metrics are requested so the expensive O(N²) pass is not repeated.
+   Both local and distributed silhouette paths normalize singleton clusters to
+   neutral `0.0`, short-circuit to neutral scores when fewer than two populated
+   clusters remain after vector filtering, and distributed workers/keys are
+   cleaned up via `try/finally` even when worker orchestration errors occur.
 
 ## Explicit exclusions
 

--- a/src/vector_topic_modeling/distributed.py
+++ b/src/vector_topic_modeling/distributed.py
@@ -30,6 +30,7 @@ def calculate_distributed_metrics(
     vectors_by_text: dict[str, list[float]],
     valkey_url: str = "redis://localhost:6379",
     num_workers: int = 4,
+    precomputed_silhouette: float | None = None,
 ) -> ClusteringMetrics:
     """Calculate extended metrics using Valkey for distributed distance calculation."""
     if not VALKEY_AVAILABLE:
@@ -39,7 +40,11 @@ def calculate_distributed_metrics(
 
     # Extended metrics (CH, DB, Coherence) are O(K*N) or O(K^2), so we do them locally
     # The silhouette score is O(N^2), so we distribute it.
-    base_metrics = calculate_extended_metrics(clusters, vectors_by_text)
+    base_metrics = calculate_extended_metrics(
+        clusters,
+        vectors_by_text,
+        precomputed_silhouette=precomputed_silhouette,
+    )
 
     if len(clusters) < 2:
         return base_metrics
@@ -55,6 +60,11 @@ def calculate_distributed_metrics(
             break
 
     if not has_vectors:
+        return base_metrics
+
+    # If silhouette was already computed by the pipeline, avoid duplicating
+    # distributed O(N^2) work and reuse the precomputed value.
+    if precomputed_silhouette is not None:
         return base_metrics
 
     client = valkey.Valkey.from_url(valkey_url, decode_responses=True)
@@ -76,6 +86,7 @@ def calculate_distributed_metrics(
 
     non_empty_clusters = sum(1 for indices in cluster_indices if indices)
     if non_empty_clusters < 2:
+        base_metrics["silhouette_score"] = 0.0
         return base_metrics
 
     # Store data in Valkey
@@ -84,30 +95,32 @@ def calculate_distributed_metrics(
     tasks_key = f"{job_id}:tasks"
     results_key = f"{job_id}:results"
 
-    client.set(vectors_key, json.dumps(flat_vectors))
-    client.set(clusters_key, json.dumps(cluster_indices))
+    results: dict[str, str] = {}
+    try:
+        client.set(vectors_key, json.dumps(flat_vectors))
+        client.set(clusters_key, json.dumps(cluster_indices))
 
-    tasks = list(range(len(flat_vectors)))
-    client.rpush(tasks_key, *tasks)
+        tasks = list(range(len(flat_vectors)))
+        client.rpush(tasks_key, *tasks)
 
-    # Start workers
-    threads = []
-    for _ in range(num_workers):
-        t = threading.Thread(target=_worker_loop, args=(valkey_url, job_id))
-        t.start()
-        threads.append(t)
+        # Start workers
+        threads = []
+        for _ in range(num_workers):
+            t = threading.Thread(target=_worker_loop, args=(valkey_url, job_id))
+            t.start()
+            threads.append(t)
 
-    for t in threads:
-        t.join()
+        for t in threads:
+            t.join()
 
-    # Read results
-    results = client.hgetall(results_key)
-
-    # Clean up
-    client.delete(vectors_key)
-    client.delete(clusters_key)
-    client.delete(tasks_key)
-    client.delete(results_key)
+        # Read results
+        results = client.hgetall(results_key)
+    finally:
+        # Clean up
+        client.delete(vectors_key)
+        client.delete(clusters_key)
+        client.delete(tasks_key)
+        client.delete(results_key)
 
     if not results or len(results) != len(flat_vectors):
         # Fallback if workers failed
@@ -162,14 +175,15 @@ def _worker_loop(valkey_url: str, job_id: str) -> None:
 
         # Calculate a_i
         same_cluster_indices = cluster_indices[c_i]
-        if len(same_cluster_indices) > 1:
-            a_i = sum(
-                1.0 - cosine_similarity(v_i, vectors[j])
-                for j in same_cluster_indices
-                if j != i
-            ) / (len(same_cluster_indices) - 1)
-        else:
-            a_i = 0.0
+        if len(same_cluster_indices) == 1:
+            client.hset(results_key, str(i), "0.0")
+            continue
+
+        a_i = sum(
+            1.0 - cosine_similarity(v_i, vectors[j])
+            for j in same_cluster_indices
+            if j != i
+        ) / (len(same_cluster_indices) - 1)
 
         # Calculate b_i
         b_i = float("inf")

--- a/src/vector_topic_modeling/evaluation.py
+++ b/src/vector_topic_modeling/evaluation.py
@@ -223,8 +223,7 @@ def calculate_extended_metrics(
                 r_ij = LARGE_DB_PENALTY
             else:
                 r_ij = (scatter[i] + scatter[j]) / dist_ij
-            if r_ij > max_r:
-                max_r = r_ij
+            max_r = max(max_r, r_ij)
             found_other = True
 
         if found_other:

--- a/src/vector_topic_modeling/evaluation.py
+++ b/src/vector_topic_modeling/evaluation.py
@@ -23,6 +23,9 @@ class SilhouetteResult(TypedDict):
     cluster_scores: dict[str, float]
 
 
+LARGE_DB_PENALTY = 1_000_000.0
+
+
 def calculate_silhouette_score(
     clusters: list[tuple[str, list[str]]],
     vectors_by_text: dict[str, list[float]],
@@ -65,14 +68,18 @@ def calculate_silhouette_score(
         valid_points = 0
 
         for v_idx, v in enumerate(vecs_i):
-            if len(vecs_i) > 1:
-                a_i = sum(
-                    (1.0 - cosine_similarity(v, other_v))
-                    for other_idx, other_v in enumerate(vecs_i)
-                    if other_idx != v_idx
-                ) / (len(vecs_i) - 1)
-            else:
-                a_i = 0.0
+            if len(vecs_i) == 1:
+                s_i = 0.0
+                cluster_total_score += s_i
+                overall_scores.append(s_i)
+                valid_points += 1
+                continue
+
+            a_i = sum(
+                (1.0 - cosine_similarity(v, other_v))
+                for other_idx, other_v in enumerate(vecs_i)
+                if other_idx != v_idx
+            ) / (len(vecs_i) - 1)
 
             b_i = float("inf")
             for j, vecs_j in enumerate(cluster_vectors):
@@ -113,6 +120,7 @@ def compute_centroid(vectors: list[list[float]]) -> list[float]:
 def calculate_extended_metrics(
     clusters: list[tuple[str, list[str]]],
     vectors_by_text: dict[str, list[float]],
+    precomputed_silhouette: float | None = None,
 ) -> ClusteringMetrics:
     """Calculate Silhouette, Calinski-Harabasz, Davies-Bouldin, and Coherence metrics."""
     if len(clusters) < 2:
@@ -149,7 +157,12 @@ def calculate_extended_metrics(
     centroids = [compute_centroid(cv) for cv in cluster_vectors]
 
     # 1. Silhouette Score
-    silhouette_res = calculate_silhouette_score(clusters, vectors_by_text)
+    if precomputed_silhouette is None:
+        silhouette_score = calculate_silhouette_score(clusters, vectors_by_text)[
+            "overall_score"
+        ]
+    else:
+        silhouette_score = precomputed_silhouette
 
     # 2. Topic Coherence (Intra-cluster Similarity) & Scatter for DB
     topic_coherence: dict[str, float] = {}
@@ -206,21 +219,21 @@ def calculate_extended_metrics(
                 continue
             dist_ij = max(0.0, 1.0 - cosine_similarity(centroids[i], centroids[j]))
             if dist_ij == 0.0:
-                # To avoid division by zero, consider very close centroids as having a high penalty
-                r_ij = float("inf")
+                # Strong finite penalty for overlapping centroids.
+                r_ij = LARGE_DB_PENALTY
             else:
                 r_ij = (scatter[i] + scatter[j]) / dist_ij
             if r_ij > max_r:
                 max_r = r_ij
             found_other = True
 
-        if found_other and max_r != float("inf"):
+        if found_other:
             db_ratios.append(max_r)
 
     db_score = sum(db_ratios) / len(db_ratios) if db_ratios else 0.0
 
     return {
-        "silhouette_score": silhouette_res["overall_score"],
+        "silhouette_score": silhouette_score,
         "calinski_harabasz_score": ch_score,
         "davies_bouldin_score": db_score,
         "topic_coherence": topic_coherence,

--- a/src/vector_topic_modeling/pipeline.py
+++ b/src/vector_topic_modeling/pipeline.py
@@ -189,6 +189,10 @@ class TopicModeler:
         if self.config.calculate_silhouette:
             silhouette = calculate_silhouette_score(cluster_input, vectors_by_text)
 
+        precomputed_silhouette = (
+            silhouette["overall_score"] if silhouette is not None else None
+        )
+
         if self.config.calculate_extended_metrics:
             if self.config.use_distributed_evaluation:
                 extended_metrics = calculate_distributed_metrics(
@@ -196,12 +200,15 @@ class TopicModeler:
                     vectors_by_text,
                     valkey_url=self.config.valkey_url,
                     num_workers=self.config.valkey_workers,
+                    precomputed_silhouette=precomputed_silhouette,
                 )
             else:
                 from vector_topic_modeling.evaluation import calculate_extended_metrics
 
                 extended_metrics = calculate_extended_metrics(
-                    cluster_input, vectors_by_text
+                    cluster_input,
+                    vectors_by_text,
+                    precomputed_silhouette=precomputed_silhouette,
                 )
 
         return TopicModelResult(

--- a/tests/test_distributed.py
+++ b/tests/test_distributed.py
@@ -128,6 +128,26 @@ def test_worker_loop_single_element_cluster(mock_valkey_client, mocker):
     assert res["silhouette_score"] > 0.0
 
 
+def test_worker_loop_singleton_point_returns_zero(mock_valkey_client):
+    mock_valkey_client.set(
+        "singleton_job:vectors",
+        json.dumps(
+            [
+                [1.0, 0.0],
+                [0.0, 1.0],
+                [0.1, 0.9],
+            ]
+        ),
+    )
+    mock_valkey_client.set("singleton_job:clusters", json.dumps([[0], [1, 2]]))
+    mock_valkey_client.rpush("singleton_job:tasks", 0)
+
+    distributed._worker_loop("redis://localhost:6379", "singleton_job")
+
+    res = mock_valkey_client.hgetall("singleton_job:results")
+    assert res["0"] == "0.0"
+
+
 def test_worker_loop_empty_cluster(mock_valkey_client, mocker):
     mocker.patch("vector_topic_modeling.distributed.VALKEY_AVAILABLE", True)
     clusters = [("c1", ["a", "b"]), ("c2", []), ("c3", ["c", "d"])]
@@ -154,6 +174,46 @@ def test_calculate_distributed_metrics_worker_fallback(mock_valkey_client, mocke
 
     # It should fallback to base metrics which has silhouette_score calculated locally
     assert res["silhouette_score"] > 0.0
+
+
+def test_calculate_distributed_metrics_reuses_precomputed_silhouette(
+    mock_valkey_client, mocker
+):
+    mocker.patch("vector_topic_modeling.distributed.VALKEY_AVAILABLE", True)
+    base_metrics = {
+        "silhouette_score": 0.77,
+        "calinski_harabasz_score": 1.11,
+        "davies_bouldin_score": 0.22,
+        "topic_coherence": {"c1": 0.9, "c2": 0.8},
+    }
+    metrics_mock = mocker.patch(
+        "vector_topic_modeling.distributed.calculate_extended_metrics",
+        return_value=base_metrics,
+    )
+
+    clusters = [("c1", ["a", "b"]), ("c2", ["c", "d"])]
+    vectors = {
+        "a": [1.0, 0.0],
+        "b": [0.9, 0.1],
+        "c": [0.0, 1.0],
+        "d": [0.1, 0.9],
+    }
+
+    res = distributed.calculate_distributed_metrics(
+        clusters,
+        vectors,
+        precomputed_silhouette=0.77,
+        num_workers=1,
+    )
+
+    assert res == base_metrics
+    metrics_mock.assert_called_once_with(
+        clusters,
+        vectors,
+        precomputed_silhouette=0.77,
+    )
+    mock_valkey_client.set.assert_not_called()
+    mock_valkey_client.hgetall.assert_not_called()
 
 
 def test_calculate_distributed_metrics_partial_results_fallback(
@@ -184,6 +244,29 @@ def test_calculate_distributed_metrics_partial_results_fallback(
     res = distributed.calculate_distributed_metrics(clusters, vectors, num_workers=0)
 
     assert res == base_metrics
+
+
+def test_calculate_distributed_metrics_cleans_up_even_on_runtime_error(
+    mock_valkey_client, mocker
+):
+    mocker.patch("vector_topic_modeling.distributed.VALKEY_AVAILABLE", True)
+    clusters = [("c1", ["a", "b"]), ("c2", ["c", "d"])]
+    vectors = {
+        "a": [1.0, 0.0],
+        "b": [0.9, 0.1],
+        "c": [0.0, 1.0],
+        "d": [0.1, 0.9],
+    }
+
+    mock_valkey_client.rpush.side_effect = RuntimeError("rpush boom")
+
+    with pytest.raises(RuntimeError, match="rpush boom"):
+        distributed.calculate_distributed_metrics(clusters, vectors, num_workers=1)
+
+    deleted_keys = [call.args[0] for call in mock_valkey_client.delete.call_args_list]
+    assert len(deleted_keys) >= 4
+    deleted_suffixes = {key.rsplit(":", maxsplit=1)[1] for key in deleted_keys}
+    assert {"vectors", "clusters", "tasks", "results"}.issubset(deleted_suffixes)
 
 
 def test_valkey_import_error_exposes_patchable_symbol():
@@ -272,12 +355,13 @@ def test_worker_loop_multiple_clusters_mean_dist_not_less(mock_valkey_client):
         json.dumps(
             [
                 [1.0, 0.0],
+                [0.9, 0.1],
                 [0.0, 1.0],
-                [0.5, 0.5],
+                [0.8, 0.2],
             ]
         ),
     )
-    mock_valkey_client.set("test_job3:clusters", json.dumps([[0], [1], [2]]))
+    mock_valkey_client.set("test_job3:clusters", json.dumps([[0, 1], [2], [3]]))
     mock_valkey_client.rpush("test_job3:tasks", 0)
 
     distributed._worker_loop("redis://localhost:6379", "test_job3")
@@ -292,7 +376,8 @@ def test_worker_loop_multiple_clusters_mean_dist_not_less(mock_valkey_client):
         json.dumps(
             [
                 [1.0, 0.0],
-                [0.5, 0.5],
+                [0.9, 0.1],
+                [0.8, 0.2],
                 [0.0, 1.0],
             ]
         ),
@@ -300,4 +385,5 @@ def test_worker_loop_multiple_clusters_mean_dist_not_less(mock_valkey_client):
     mock_valkey_client.rpush("test_job3:tasks", 0)
     distributed._worker_loop("redis://localhost:6379", "test_job3")
     second_res = mock_valkey_client.hgetall("test_job3:results")
-    assert second_res["0"] == "1.0"
+    assert "0" in second_res
+    assert -1.0 <= float(second_res["0"]) <= 1.0

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import math
+
 from vector_topic_modeling.evaluation import (
     calculate_extended_metrics,
     calculate_silhouette_score,
@@ -28,6 +30,7 @@ def test_silhouette_score_calculation():
     assert "c1" in result["cluster_scores"]
     assert "c2" in result["cluster_scores"]
     assert "c3" in result["cluster_scores"]
+    assert result["cluster_scores"]["c3"] == 0.0
 
 
 def test_silhouette_score_single_cluster():
@@ -109,6 +112,28 @@ def test_calculate_extended_metrics_valid() -> None:
     assert res["topic_coherence"]["c2"] > 0.9
 
 
+def test_calculate_extended_metrics_uses_precomputed_silhouette(mocker) -> None:
+    clusters = [("c1", ["a", "b"]), ("c2", ["c", "d"])]
+    vectors = {
+        "a": [1.0, 0.0],
+        "b": [0.9, 0.1],
+        "c": [0.0, 1.0],
+        "d": [0.1, 0.9],
+    }
+    silhouette_mock = mocker.patch(
+        "vector_topic_modeling.evaluation.calculate_silhouette_score"
+    )
+
+    res = calculate_extended_metrics(
+        clusters,
+        vectors,
+        precomputed_silhouette=0.123,
+    )
+
+    assert res["silhouette_score"] == 0.123
+    silhouette_mock.assert_not_called()
+
+
 def test_calculate_extended_metrics_empty_cluster() -> None:
     clusters = [("c1", ["a"]), ("c2", ["x"]), ("c3", ["b"])]  # no vector
     vectors = {
@@ -116,7 +141,7 @@ def test_calculate_extended_metrics_empty_cluster() -> None:
         "b": [0.0, 1.0],
     }
     res = calculate_extended_metrics(clusters, vectors)
-    assert res["silhouette_score"] > 0.0
+    assert res["silhouette_score"] == 0.0
     assert "c2" in res["topic_coherence"]
     assert res["topic_coherence"]["c2"] == 0.0
 
@@ -132,8 +157,8 @@ def test_calculate_extended_metrics_identical_centroids() -> None:
     }
     res = calculate_extended_metrics(clusters, vectors)
     assert res["calinski_harabasz_score"] == 0.0
-    # DB score might be 0.0 or 0.0 depending on max_r accumulation
-    assert res["davies_bouldin_score"] == 0.0
+    assert math.isfinite(res["davies_bouldin_score"])
+    assert res["davies_bouldin_score"] > 0.0
 
 
 def test_calculate_extended_metrics_db_infinity() -> None:
@@ -162,7 +187,8 @@ def test_calculate_extended_metrics_db_dist_zero():
         "b": [1.0, 0.0],  # Identical to 'a' to make dist_ij == 0.0
     }
     res = calculate_extended_metrics(clusters, vectors)
-    assert res["davies_bouldin_score"] == 0.0
+    assert math.isfinite(res["davies_bouldin_score"])
+    assert res["davies_bouldin_score"] > 0.0
 
 
 def test_calculate_extended_metrics_db_smaller_r_ij():

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -289,3 +289,134 @@ def test_pipeline_extended_metrics_distributed(mocker) -> None:
     mock_calc.assert_called_once()
     assert result.extended_metrics is not None
     assert result.extended_metrics["silhouette_score"] == 1.0
+
+
+def test_pipeline_reuses_precomputed_silhouette_for_local_extended_metrics(
+    mocker,
+) -> None:
+    provider = FakeEmbeddingProvider(
+        {
+            "apple orange": [1.0, 0.0],
+            "cat dog": [0.0, 1.0],
+        }
+    )
+    docs = [
+        TopicDocument(id="1", text="apple orange"),
+        TopicDocument(id="2", text="apple orange"),
+        TopicDocument(id="3", text="cat dog"),
+        TopicDocument(id="4", text="cat dog"),
+    ]
+    modeler = TopicModeler(
+        embedding_provider=provider,
+        config=TopicModelConfig(
+            min_topics=2,
+            max_topics=2,
+            calculate_silhouette=True,
+            calculate_extended_metrics=True,
+            use_distributed_evaluation=False,
+        ),
+    )
+
+    mocker.patch(
+        "vector_topic_modeling.pipeline.calculate_silhouette_score",
+        return_value={"overall_score": 0.4, "cluster_scores": {"t1": 0.4}},
+    )
+    extended_mock = mocker.patch(
+        "vector_topic_modeling.evaluation.calculate_extended_metrics",
+        return_value={
+            "silhouette_score": 0.4,
+            "calinski_harabasz_score": 1.0,
+            "davies_bouldin_score": 0.3,
+            "topic_coherence": {},
+        },
+    )
+
+    modeler.fit_predict(docs)
+
+    assert extended_mock.call_args.kwargs["precomputed_silhouette"] == 0.4
+
+
+def test_pipeline_reuses_precomputed_silhouette_for_distributed_metrics(
+    mocker,
+) -> None:
+    provider = FakeEmbeddingProvider(
+        {
+            "apple orange": [1.0, 0.0],
+            "cat dog": [0.0, 1.0],
+        }
+    )
+    docs = [
+        TopicDocument(id="1", text="apple orange"),
+        TopicDocument(id="2", text="apple orange"),
+        TopicDocument(id="3", text="cat dog"),
+        TopicDocument(id="4", text="cat dog"),
+    ]
+    modeler = TopicModeler(
+        embedding_provider=provider,
+        config=TopicModelConfig(
+            min_topics=2,
+            max_topics=2,
+            calculate_silhouette=True,
+            calculate_extended_metrics=True,
+            use_distributed_evaluation=True,
+        ),
+    )
+
+    mocker.patch(
+        "vector_topic_modeling.pipeline.calculate_silhouette_score",
+        return_value={"overall_score": 0.55, "cluster_scores": {"t1": 0.55}},
+    )
+    distributed_mock = mocker.patch(
+        "vector_topic_modeling.pipeline.calculate_distributed_metrics",
+        return_value={
+            "silhouette_score": 0.55,
+            "calinski_harabasz_score": 1.2,
+            "davies_bouldin_score": 0.2,
+            "topic_coherence": {},
+        },
+    )
+
+    modeler.fit_predict(docs)
+
+    assert distributed_mock.call_args.kwargs["precomputed_silhouette"] == 0.55
+
+
+def test_pipeline_extended_metrics_without_silhouette_passes_none_precomputed(
+    mocker,
+) -> None:
+    provider = FakeEmbeddingProvider(
+        {
+            "apple orange": [1.0, 0.0],
+            "cat dog": [0.0, 1.0],
+        }
+    )
+    docs = [
+        TopicDocument(id="1", text="apple orange"),
+        TopicDocument(id="2", text="apple orange"),
+        TopicDocument(id="3", text="cat dog"),
+        TopicDocument(id="4", text="cat dog"),
+    ]
+    modeler = TopicModeler(
+        embedding_provider=provider,
+        config=TopicModelConfig(
+            min_topics=2,
+            max_topics=2,
+            calculate_silhouette=False,
+            calculate_extended_metrics=True,
+            use_distributed_evaluation=False,
+        ),
+    )
+
+    extended_mock = mocker.patch(
+        "vector_topic_modeling.evaluation.calculate_extended_metrics",
+        return_value={
+            "silhouette_score": 0.1,
+            "calinski_harabasz_score": 1.0,
+            "davies_bouldin_score": 0.2,
+            "topic_coherence": {},
+        },
+    )
+
+    modeler.fit_predict(docs)
+
+    assert extended_mock.call_args.kwargs["precomputed_silhouette"] is None


### PR DESCRIPTION
## Summary
- reuse precomputed silhouette values in the distributed extended-metrics path to avoid repeating O(N²) silhouette work when pipeline silhouette is already computed
- normalize singleton-point silhouette handling to `0.0` across local/distributed paths and harden distributed Valkey cleanup with `try/finally`
- extend tests for precomputed forwarding, runtime-error cleanup coverage, and finite Davies-Bouldin penalty semantics; update architecture docs to match runtime behavior

## Verification
- `uv run pytest -q`
- `uv run python scripts/docstring_coverage.py --min-percent 100`
- `uv run mypy src tests`
- `rm -rf dist .venv-smoke-cli && uv run python -m build && uv run python scripts/smoke_installed_cli.py --dist-dir dist --venv-dir .venv-smoke-cli`
- `lint_by_filetype --dryRun=false --json`

<!-- coderabbit_walkthrough_start -->
<!-- walkthrough_start -->
<details open>
<summary>📝 Walkthrough</summary>

## 둘러보기

평가 파이프라인이 실루엣 점수를 사전에 계산하여 확장 메트릭 계산에서 재사용하는 최적화를 구현합니다. 정규화된 싱글톤 클러스터 처리, 배포 환경에서의 예외-안전 정리, 그리고 대규모 페널티 기반 Davies-Bouldin 계산이 추가됩니다.

## 변경사항

|코호트 / 파일(들)|요약|
|---|---|
|**아키텍처 문서** <br> `ARCHITECTURE.md`|실루엣 점수 재사용, 싱글톤 정규화, 분산 경로 정리를 명시하는 평가 파이프라인 설명 업데이트.|
|**핵심 평가 로직** <br> `src/vector_topic_modeling/evaluation.py`|`LARGE_DB_PENALTY` 상수 추가, 싱글톤 클러스터 명시적 처리 (0.0 할당), 선택적 `precomputed_silhouette` 매개변수 추가 및 Davies-Bouldin 페널티 처리 변경.|
|**분산 메트릭 계산** <br> `src/vector_topic_modeling/distributed.py`|`calculate_distributed_metrics`에 `precomputed_silhouette` 매개변수 추가, 제공된 값 사용 시 조기 반환, Valkey 정리를 `try/finally`로 예외-안전 처리, `_worker_loop`의 싱글톤 처리 최적화.|
|**파이프라인 통합** <br> `src/vector_topic_modeling/pipeline.py`|`fit_predict`에서 계산된 실루엣 점수를 `precomputed_silhouette`으로 추출하여 분산 및 로컬 확장 메트릭 함수에 전달.|
|**분산 메트릭 테스트** <br> `tests/test_distributed.py`|싱글톤 포인트 처리, 사전계산된 실루엣 재사용, 런타임 오류 발생 시 정리 검증 테스트 추가; 기존 픽스처 및 어설션 업데이트.|
|**평가 로직 테스트** <br> `tests/test_evaluation.py`|싱글톤 클러스터 0.0 검증, `precomputed_silhouette` 전달 테스트, Davies-Bouldin 엣지 케이스 어설션 조정 (유한성 및 양수 확인).|
|**파이프라인 테스트** <br> `tests/test_pipeline.py`|로컬 및 분산 경로에서 `precomputed_silhouette` 전달 검증, 실루엣 비활성화 시 `None` 전달 확인하는 3개 새 테스트 추가.|

## 시퀀스 다이어그램

```mermaid
sequenceDiagram
    actor Pipeline as 파이프라인
    participant Silhouette as 실루엣<br/>계산
    participant Extended as 확장 메트릭
    participant Distributed as 분산<br/>메트릭
    
    Pipeline->>Silhouette: 실루엣 점수 계산
    Silhouette-->>Pipeline: overall_score
    
    Pipeline->>Extended: precomputed_silhouette 포함<br/>호출 (로컬)
    Extended->>Extended: 사전계산된 값 사용<br/>(재계산 건너뜀)
    Extended-->>Pipeline: 확장 메트릭
    
    Pipeline->>Distributed: precomputed_silhouette 포함<br/>호출 (분산)
    Distributed->>Distributed: Valkey 계산 건너뜀
    Distributed->>Extended: precomputed_silhouette 전달
    Extended-->>Distributed: 확장 메트릭
    Distributed-->>Pipeline: 최종 메트릭
```

## 예상 코드 검토 노력

🎯 3 (보통) | ⏱️ ~35분

## 시

> 🐰 시루엣을 한 번만 계산하고,  
> 분산 경로에서 재사용하며,  
> 싱글톤은 중립 점수로 정렬하고,  
> 정리는 예외에 견디어내니—  
> 효율의 정원이 피어난다! 🌸

</details>
<!-- walkthrough_end -->
<!-- coderabbit_walkthrough_end -->