### PR TITLE
docs: fix Korean manual base-url contract example

### DIFF
--- a/docs/user-manual-general-ko.md
+++ b/docs/user-manual-general-ko.md
@@ -42,7 +42,7 @@
 ```bash
 vector-topic-modeling cluster my_documents.jsonl \
   --output topics_output.json \
-  --base-url "https://api.openai.com/v1" \
+  --base-url "https://api.openai.com" \
   --api-key "sk-..." \
   --model text-embedding-3-large \
   --similarity-threshold 0.80 \

--- a/tests/test_contributor_doc_policy_alignment.py
+++ b/tests/test_contributor_doc_policy_alignment.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+import re
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
@@ -125,5 +126,8 @@ def test_general_korean_manual_matches_python_api_contract() -> None:
 def test_general_korean_manual_uses_base_url_without_v1_suffix() -> None:
     content = _read("docs/user-manual-general-ko.md")
 
-    assert '--base-url "https://api.openai.com"' in content
-    assert '--base-url "https://api.openai.com/v1"' not in content
+    base_url_values = re.findall(r'--base-url\s+"([^"]+)"', content)
+
+    assert base_url_values, "docs/user-manual-general-ko.md missing --base-url examples"
+    assert "https://api.openai.com" in base_url_values
+    assert all(not url.rstrip("/").endswith("/v1") for url in base_url_values)

--- a/tests/test_contributor_doc_policy_alignment.py
+++ b/tests/test_contributor_doc_policy_alignment.py
@@ -120,3 +120,10 @@ def test_general_korean_manual_matches_python_api_contract() -> None:
     assert "topic.id" not in content
     assert "topic.count" not in content
     assert "topic.display_texts" not in content
+
+
+def test_general_korean_manual_uses_base_url_without_v1_suffix() -> None:
+    content = _read("docs/user-manual-general-ko.md")
+
+    assert '--base-url "https://api.openai.com"' in content
+    assert '--base-url "https://api.openai.com/v1"' not in content


### PR DESCRIPTION
## Summary
- correct the Korean general manual CLI example to use `--base-url "https://api.openai.com"` so runtime requests do not double-append `/v1`
- add a regression doc-policy test that enforces base-url examples in that manual stay free of a `/v1` suffix
- keep existing Korean manual API-contract assertions aligned with current provider/runtime behavior

## Verification
- `uv run pytest -q`
- `uv run python scripts/docstring_coverage.py --min-percent 100`
- `uv run mypy src tests`
- `rm -rf dist .venv-smoke-cli && uv run python -m build && uv run python scripts/smoke_installed_cli.py --dist-dir dist --venv-dir .venv-smoke-cli`
- `lint_by_filetype --dryRun=false --json`